### PR TITLE
- Changed create_comments migrations' FK from CASCADE to RESTRICT, so…

### DIFF
--- a/comments/src/main/java/ua/nin/comments/controller/CommentController.java
+++ b/comments/src/main/java/ua/nin/comments/controller/CommentController.java
@@ -1,0 +1,57 @@
+package ua.nin.comments.controller;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import ua.nin.comments.dto.*;
+import ua.nin.comments.service.CommentService;
+
+@RestController
+@RequestMapping("/api/v1/comments")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping
+    public ResponseEntity<CommentResponse> create(Authentication auth, @Valid @RequestBody CreateCommentRequest req) {
+        long userId = Long.parseLong(auth.getName());
+        return ResponseEntity.ok(commentService.create(userId, req));
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<CommentResponse>> listRoot(@RequestParam @NotNull String targetType,
+                                                          @RequestParam @NotNull @Positive Long targetId,
+                                                          @PageableDefault(page = 0, size = 20) Pageable pageable
+    ) {
+        return ResponseEntity.ok(commentService.listRoot(targetType, targetId, pageable));
+    }
+
+    @GetMapping("/{parentId}/replies")
+    public ResponseEntity<Page<CommentResponse>> listReplies(@PathVariable long parentId,
+                                                             @PageableDefault(page = 0, size = 5) Pageable pageable) {
+        return ResponseEntity.ok(commentService.listReplies(parentId, pageable));
+    }
+
+    @PatchMapping("/{commentId}")
+    public ResponseEntity<CommentResponse> update(Authentication auth,
+                                                  @PathVariable long commentId,
+                                                  @Valid @RequestBody UpdateCommentRequest req) {
+        long userId = Long.parseLong(auth.getName());
+        return ResponseEntity.ok(commentService.update(userId, commentId, req));
+    }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<Void> delete(Authentication auth, @PathVariable long commentId) {
+        long userId = Long.parseLong(auth.getName());
+        commentService.delete(userId, commentId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/comments/src/main/java/ua/nin/comments/dto/CommentResponse.java
+++ b/comments/src/main/java/ua/nin/comments/dto/CommentResponse.java
@@ -1,0 +1,17 @@
+package ua.nin.comments.dto;
+
+import ua.nin.comments.model.CommentStatus;
+
+import java.time.Instant;
+
+public record CommentResponse(
+        long id,
+        long authorUserId,
+        String targetType,
+        long targetId,
+        Long parentId,
+        String body,
+        CommentStatus status,
+        Instant createdAt,
+        Instant updatedAt
+) {}

--- a/comments/src/main/java/ua/nin/comments/dto/CreateCommentRequest.java
+++ b/comments/src/main/java/ua/nin/comments/dto/CreateCommentRequest.java
@@ -1,0 +1,12 @@
+package ua.nin.comments.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CreateCommentRequest(
+        @NotNull String targetType,
+        @NotNull Long targetId,
+        Long parentId,
+        @NotBlank @Size(max = 500) String body
+) {}

--- a/comments/src/main/java/ua/nin/comments/dto/UpdateCommentRequest.java
+++ b/comments/src/main/java/ua/nin/comments/dto/UpdateCommentRequest.java
@@ -1,0 +1,8 @@
+package ua.nin.comments.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdateCommentRequest(
+        @NotBlank @Size(max = 500) String body
+) {}

--- a/comments/src/main/java/ua/nin/comments/exception/exceptions/BadRequestException.java
+++ b/comments/src/main/java/ua/nin/comments/exception/exceptions/BadRequestException.java
@@ -1,0 +1,7 @@
+package ua.nin.comments.exception.exceptions;
+
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/comments/src/main/java/ua/nin/comments/exception/exceptions/ForbiddenException.java
+++ b/comments/src/main/java/ua/nin/comments/exception/exceptions/ForbiddenException.java
@@ -1,0 +1,7 @@
+package ua.nin.comments.exception.exceptions;
+
+public class ForbiddenException extends RuntimeException {
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/comments/src/main/java/ua/nin/comments/exception/exceptions/NotFoundException.java
+++ b/comments/src/main/java/ua/nin/comments/exception/exceptions/NotFoundException.java
@@ -1,0 +1,7 @@
+package ua.nin.comments.exception.exceptions;
+
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/comments/src/main/java/ua/nin/comments/mapper/CommentResponseMapper.java
+++ b/comments/src/main/java/ua/nin/comments/mapper/CommentResponseMapper.java
@@ -1,0 +1,21 @@
+package ua.nin.comments.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import ua.nin.comments.dto.CommentResponse;
+import ua.nin.comments.model.Comment;
+import ua.nin.comments.model.CommentStatus;
+
+@Mapper(componentModel = "spring")
+public interface CommentResponseMapper {
+    CommentResponse toDto(Comment comment);
+
+    @Mapping(target = "body", qualifiedByName = "mapPublicBody")
+    CommentResponse toDtoPublic(Comment comment);
+
+    @Named("mapPublicBody")
+    default String mapPublicBody(Comment comment) {
+        return (comment.getStatus() == CommentStatus.ACTIVE) ? comment.getBody() : "[hidden]";
+    }
+}

--- a/comments/src/main/java/ua/nin/comments/model/Comment.java
+++ b/comments/src/main/java/ua/nin/comments/model/Comment.java
@@ -1,0 +1,68 @@
+package ua.nin.comments.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor @Builder
+@Entity
+@Table(schema = "comments", name = "comments",
+        indexes = {
+                @Index(name = "idx_comments_target", columnList = "target_type,target_id,created_at"),
+                @Index(name = "idx_comments_parent", columnList = "parent_id,created_at"),
+                @Index(name = "idx_comments_author", columnList = "author_user_id")
+        }
+)
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "author_user_id", nullable = false)
+    private Long authorUserId;
+
+    @Column(name = "target_type", nullable = false, length = 64)
+    private String targetType;
+
+    @Column(name = "target_id", nullable = false)
+    private Long targetId;
+
+    @Column(name = "parent_id")
+    private Long parentId;
+
+    @Column(name = "body", nullable = false, length = 500)
+    private String body;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 16)
+    private CommentStatus status;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @Column(name = "deleted_at")
+    private Instant deletedAt;
+
+    @PrePersist
+    void prePersist() {
+        Instant now = Instant.now();
+        createdAt = now;
+        updatedAt = now;
+        if (status == null) status = CommentStatus.ACTIVE;
+    }
+
+    @PreUpdate
+    void preUpdate() {
+        updatedAt = Instant.now();
+    }
+
+    public boolean isActive() {
+        return status == CommentStatus.ACTIVE;
+    }
+}

--- a/comments/src/main/java/ua/nin/comments/model/CommentStatus.java
+++ b/comments/src/main/java/ua/nin/comments/model/CommentStatus.java
@@ -1,0 +1,5 @@
+package ua.nin.comments.model;
+
+public enum CommentStatus {
+    ACTIVE, DELETED, HIDDEN
+}

--- a/comments/src/main/java/ua/nin/comments/repository/CommentClosureRepository.java
+++ b/comments/src/main/java/ua/nin/comments/repository/CommentClosureRepository.java
@@ -1,0 +1,34 @@
+package ua.nin.comments.repository;
+
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+public interface CommentClosureRepository extends Repository<Object, Long> {
+
+    @Modifying
+    @Query(value = """
+        INSERT INTO comments.comment_closure (ancestor_id, descendant_id, depth)
+        VALUES (:id, :id, 0)
+        """, nativeQuery = true)
+    void insertSelf(@Param("id") long id);
+
+    @Modifying
+    @Query(value = """
+        INSERT INTO comments.comment_closure (ancestor_id, descendant_id, depth)
+        SELECT cc.ancestor_id, :newId, cc.depth + 1
+        FROM comments.comment_closure cc
+        WHERE cc.descendant_id = :parentId
+        UNION ALL
+        SELECT :newId, :newId, 0
+        """, nativeQuery = true)
+    void insertForReply(@Param("parentId") long parentId, @Param("newId") long newId);
+
+    @Query(value = """
+        SELECT COALESCE(MAX(depth), 0)
+        FROM comments.comment_closure
+        WHERE descendant_id = :commentId
+        """, nativeQuery = true)
+    int maxDepthFromAncestors(@Param("commentId") long commentId);
+}

--- a/comments/src/main/java/ua/nin/comments/repository/CommentRepository.java
+++ b/comments/src/main/java/ua/nin/comments/repository/CommentRepository.java
@@ -1,0 +1,19 @@
+package ua.nin.comments.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import ua.nin.comments.model.Comment;
+
+import java.util.Optional;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    Page<Comment> findByTargetTypeAndTargetIdAndParentIdIsNullOrderByCreatedAtDesc(
+            String targetType, Long targetId, Pageable pageable
+    );
+
+    Page<Comment> findByParentIdOrderByCreatedAtAsc(Long parentId, Pageable pageable);
+
+    Optional<Comment> findByIdAndTargetTypeAndTargetId(Long id, String targetType, Long targetId);
+}

--- a/comments/src/main/java/ua/nin/comments/service/CommentService.java
+++ b/comments/src/main/java/ua/nin/comments/service/CommentService.java
@@ -1,0 +1,124 @@
+package ua.nin.comments.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ua.nin.comments.dto.*;
+import ua.nin.comments.exception.exceptions.BadRequestException;
+import ua.nin.comments.exception.exceptions.ForbiddenException;
+import ua.nin.comments.exception.exceptions.NotFoundException;
+import ua.nin.comments.mapper.CommentResponseMapper;
+import ua.nin.comments.model.Comment;
+import ua.nin.comments.model.CommentStatus;
+import ua.nin.comments.repository.CommentClosureRepository;
+import ua.nin.comments.repository.CommentRepository;
+
+import java.time.Instant;
+import java.util.Objects;
+
+import static ua.nin.common.util.StringHelperUtils.normalizeBody;
+import static ua.nin.common.util.StringHelperUtils.normalizeTargetType;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    @Value("${comments.max-depth:20}")
+    private int maxDepth;
+
+    private final CommentRepository commentRepository;
+    private final CommentClosureRepository closureRepository;
+    private final CommentResponseMapper commentResponseMapper;
+
+    @Transactional
+    public CommentResponse create(long authorUserId, CreateCommentRequest req) {
+        String targetType = normalizeTargetType(req.targetType());
+        Long targetId = req.targetId();
+        Long parentId = req.parentId();
+
+        if (parentId != null) {
+            Comment parent = commentRepository.findById(parentId)
+                    .orElseThrow(() -> new NotFoundException("Parent comment not found"));
+
+            // батьківський коментар повинен бути в тому ж таргеті
+            if (!Objects.equals(parent.getTargetId(), targetId) || !Objects.equals(parent.getTargetType(), targetType)) {
+                throw new BadRequestException("Parent comment belongs to different target");
+            }
+
+            // глибина
+            int depth = closureRepository.maxDepthFromAncestors(parentId);
+            if (depth + 1 > maxDepth) {
+                throw new BadRequestException("Max comment depth reached");
+            }
+        }
+
+        Comment c = Comment.builder()
+                .authorUserId(authorUserId)
+                .targetType(targetType)
+                .targetId(targetId)
+                .parentId(parentId)
+                .body(normalizeBody(req.body()))
+                .status(CommentStatus.ACTIVE)
+                .build();
+
+        c = commentRepository.save(c);
+
+        // closure insert
+        if (parentId == null) {
+            closureRepository.insertSelf(c.getId());
+        } else {
+            closureRepository.insertForReply(parentId, c.getId());
+        }
+
+        return commentResponseMapper.toDto(c);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<CommentResponse> listRoot(String targetType, long targetId, Pageable pageable) {
+        return commentRepository
+                .findByTargetTypeAndTargetIdAndParentIdIsNullOrderByCreatedAtDesc(normalizeTargetType(targetType), targetId, pageable)
+                .map(commentResponseMapper::toDtoPublic);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<CommentResponse> listReplies(long parentId, Pageable pageable) {
+        return commentRepository
+                .findByParentIdOrderByCreatedAtAsc(parentId, pageable)
+                .map(commentResponseMapper::toDtoPublic);
+    }
+
+    @Transactional
+    public CommentResponse update(long userId, long commentId, UpdateCommentRequest req) {
+        Comment c = commentRepository.findById(commentId)
+                .orElseThrow(() -> new NotFoundException("Comment not found"));
+
+        if (c.getAuthorUserId() != userId) {
+            throw new ForbiddenException("Not your comment");
+        }
+        if (c.getStatus() != CommentStatus.ACTIVE) {
+            throw new BadRequestException("Comment is not active, thus is not editable");
+        }
+
+        c.setBody(normalizeBody(req.body()));
+        return commentResponseMapper.toDto(c);
+    }
+
+    @Transactional
+    public void delete(long userId, long commentId) {
+        Comment c = commentRepository.findById(commentId)
+                .orElseThrow(() -> new NotFoundException("Comment not found"));
+
+        if (c.getAuthorUserId() != userId) {
+            throw new ForbiddenException("You are not allowed to delete this comment");
+        }
+
+        if (c.getStatus() == CommentStatus.DELETED) return;
+
+        c.setStatus(CommentStatus.DELETED);
+        c.setDeletedAt(Instant.now());
+        c.setBody("[deleted]");
+    }
+}

--- a/comments/src/main/resources/db/changelog/logs/010_create_comments.xml
+++ b/comments/src/main/resources/db/changelog/logs/010_create_comments.xml
@@ -53,7 +53,7 @@
                 referencedTableName="users"
                 referencedColumnNames="id"
                 constraintName="fk_comments_author_user"
-                onDelete="CASCADE"/>
+                onDelete="RESTRICT"/>
 
         <addForeignKeyConstraint
                 baseTableSchemaName="comments"
@@ -63,7 +63,7 @@
                 referencedTableName="comments"
                 referencedColumnNames="id"
                 constraintName="fk_comments_parent"
-                onDelete="CASCADE"/>
+                onDelete="RESTRICT"/>
 
         <rollback>
             <dropTable schemaName="comments" tableName="comments"/>

--- a/comments/src/main/resources/db/changelog/logs/020_create_comment_closure.xml
+++ b/comments/src/main/resources/db/changelog/logs/020_create_comment_closure.xml
@@ -5,7 +5,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.25.xsd">
 
-    <changeSet id="092-create-comment-closure" author="Lain (Ivan)">
+    <changeSet id="020-create-comment-closure" author="Lain (Ivan)">
         <createTable tableName="comment_closure" schemaName="comments">
             <column name="ancestor_id" type="BIGINT">
                 <constraints nullable="false"/>

--- a/common/src/main/java/ua/nin/common/util/StringHelperUtils.java
+++ b/common/src/main/java/ua/nin/common/util/StringHelperUtils.java
@@ -25,18 +25,25 @@ public final class StringHelperUtils {
     }
 
     public static String normalizeAndTruncate(String s, int maxLength) {
-        String t = trimToNull(trimToNull(s));
+        String t = trimToNull(s);
         if (t == null) return null;
         return t.length() <= maxLength ? t : t.substring(0, maxLength);
     }
 
-    public static String normalizeTargetType(String s) {
-        String t = trimToNull(trimToNull(s));
+    public static String normalizeTargetType(String targetType) {
+        String t = trimToNull(targetType);
         return toRootUpperCase(t);
     }
 
-    public static String normalizeReactionCode(String s) {
-        String t = trimToNull(trimToNull(s));
+    public static String normalizeReactionCode(String reactionCode) {
+        String t = trimToNull(reactionCode);
         return toRootUpperCase(t);
+    }
+
+    public static String normalizeBody(String body) {
+        String t = trimToEmpty(body);
+        return t.length() > 500
+                ? t.substring(0, 500)
+                : t;
     }
 }


### PR DESCRIPTION
- Changed comment parent FK behavior from CASCADE to RESTRICT.
- Added Comment model, DTOs, mapper, repositories, closure-table operations, service, and controller.

## Development links
Closes #91
Closes #92
Closes #93
Closes #94
Closes #123
Closes #247
Closes #248
Closes #250
Closes #251
Closes #252
Closes #253
Closes #255
Closes #256
Closes #257
Closes #258
Closes #260
Closes #261
Closes #262
Closes #395