### PR TITLE
- Commented user-avatar logic (for deletion later), as user avatar wi…

### DIFF
--- a/identity/src/main/java/ua/nin/identity/auth/config/SecurityConfig.java
+++ b/identity/src/main/java/ua/nin/identity/auth/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package ua.nin.identity.auth.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.Customizer;
@@ -16,6 +17,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
+import org.springframework.security.web.util.matcher.OrRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 
 @Configuration
 @EnableWebSecurity
@@ -27,47 +32,66 @@ public class SecurityConfig {
     private final JwtAuthenticationConverter jwtAuthenticationConverter;
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http
+    public RequestMatcher publicMatcher() {
+        var p = PathPatternRequestMatcher.withDefaults();
+
+        return new OrRequestMatcher(
+                p.matcher(HttpMethod.POST, "/api/v1/auth/register"),
+                p.matcher(HttpMethod.POST, "/api/v1/auth/login"),
+                p.matcher(HttpMethod.POST, "/api/v1/auth/logout"),
+                p.matcher(HttpMethod.POST, "/api/v1/auth/refresh"),
+                p.matcher(HttpMethod.POST, "/api/v1/auth/email/verify"),
+                p.matcher(HttpMethod.POST, "/api/v1/auth/email/resend"),
+                p.matcher(HttpMethod.POST, "/api/v1/auth/password/forgot"),
+                p.matcher(HttpMethod.POST, "/api/v1/auth/password/reset"),
+
+                p.matcher(HttpMethod.GET, "/api/v1/auth/media/*"),
+
+                // будь-який
+                p.matcher("/actuator/**"),
+                p.matcher("/v3/api-docs/**"),
+                p.matcher("/swagger-ui/**"),
+                p.matcher("/swagger-ui.html"),
+
+                p.matcher(HttpMethod.OPTIONS, "/**")
+        );
+    }
+
+    @Bean
+    @Order(1)
+    public SecurityFilterChain publicChain(HttpSecurity http, RequestMatcher publicMatcher) throws Exception {
+        http.securityMatcher(publicMatcher)
                 // REST API -> CSRF зазвичай вимикають, бо немає server-side session.
                 // Refresh cookie в такій схемі теж ок, але якщо хочеш "максимально строго" —
                 // можемо додати CSRF token тільки для /auth/refresh.
 
                 .cors(Customizer.withDefaults())
                 .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(a -> a.anyRequest().permitAll());
+
+        return http.build();
+    }
+
+    @Bean
+    @Order(2)
+    public SecurityFilterChain protectedChain(HttpSecurity http) throws Exception {
+        http
+                .cors(Customizer.withDefaults())
+                .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .authorizeHttpRequests(auth -> auth
-                        // --- Public auth endpoints ---
-                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/register").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/login").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/refresh").permitAll()
-
-                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/email/verify").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/email/resend").permitAll()
-
-                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/password/forgot").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/password/reset").permitAll()
-
-                        // swagger / actuator (опціонально)
-                        .requestMatchers("/actuator/**").permitAll()
-                        .requestMatchers(
-                                "/v3/api-docs/**",
-                                "/swagger-ui/**",
-                                "/swagger-ui.html"
-                        ).permitAll()
-
                         // --- Protected endpoints ---
                         .requestMatchers(HttpMethod.GET, "/api/v1/auth/me").hasAnyRole("USER", "ADMIN")
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/logout-all").hasAnyRole("USER", "ADMIN")
-                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/logout").permitAll()
-                        // logout можна дозволити без access — бо revoke робиться по refresh cookie
 
                         .requestMatchers(HttpMethod.POST, "/api/v1/auth/password/change").hasAnyRole("USER", "ADMIN")
-
                         .requestMatchers("/api/v1/auth/sessions/**").hasAnyRole("USER", "ADMIN")
 
+                        .requestMatchers(HttpMethod.POST, "/api/v1/video/upload/video-with-preview").hasAnyRole("USER", "ADMIN")
+                        .requestMatchers(HttpMethod.POST, "/api/v1/media/upload").hasAnyRole("USER", "ADMIN")
                         // все інше — за замовчуванням закрите
                         .anyRequest().hasAnyRole("USER", "ADMIN")
                 )

--- a/identity/src/main/java/ua/nin/identity/auth/mapper/MeResponseMapper.java
+++ b/identity/src/main/java/ua/nin/identity/auth/mapper/MeResponseMapper.java
@@ -1,12 +1,15 @@
 package ua.nin.identity.auth.mapper;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import ua.nin.identity.auth.dto.MeResponse;
 import ua.nin.identity.auth.model.User;
 
 @Mapper(componentModel = "spring")
 public interface MeResponseMapper {
+    @Mapping(source = "id", target = "userId")
     MeResponse toDto(User user);
 
+    @Mapping(source = "userId", target = "id")
     User toEntity(MeResponse meResponseDto);
 }

--- a/identity/src/main/java/ua/nin/identity/profile/controller/ProfileController.java
+++ b/identity/src/main/java/ua/nin/identity/profile/controller/ProfileController.java
@@ -29,12 +29,12 @@ public class ProfileController {
         return ResponseEntity.ok(profileService.updateMyProfile(userId, req));
     }
 
-    @PostMapping("/me/avatar")
-    public ResponseEntity<Void> setAvatar(@Valid @RequestBody SetAvatarRequest req) {
-        long userId = SecurityUtils.currentUserId();
-        profileService.setAvatar(userId, req.mediaId());
-        return ResponseEntity.noContent().build();
-    }
+//    @PostMapping("/me/avatar")
+//    public ResponseEntity<Void> setAvatar(@Valid @RequestBody SetAvatarRequest req) {
+//        long userId = SecurityUtils.currentUserId();
+//        profileService.setAvatar(userId, req.mediaId());
+//        return ResponseEntity.noContent().build();
+//    }
 
     @GetMapping("/by-username/{username}")
     public ResponseEntity<PublicProfileResponse> publicByUsername(@PathVariable String username) {

--- a/identity/src/main/java/ua/nin/identity/profile/model/Profile.java
+++ b/identity/src/main/java/ua/nin/identity/profile/model/Profile.java
@@ -31,9 +31,6 @@ public class Profile {
     @Column(name = "display_name")
     private String displayName;
 
-    @Column(name = "avatar_media_id")
-    private Long avatarMediaId;
-
     @Column(name = "bio")
     private String bio;
 

--- a/identity/src/main/java/ua/nin/identity/profile/service/ProfileService.java
+++ b/identity/src/main/java/ua/nin/identity/profile/service/ProfileService.java
@@ -53,12 +53,12 @@ public class ProfileService {
         return profileResponseMapper.toDto(p);
     }
 
-    @Transactional
-    public void setAvatar(long userId, long mediaId) {
-        Profile p = profileRepository.findById(userId)
-                .orElseThrow(() -> new ProfileNotFoundException("Profile not found"));
-        p.setAvatarMediaId(mediaId);
-    }
+//    @Transactional
+//    public void setAvatar(long userId, long mediaId) {
+//        Profile p = profileRepository.findById(userId)
+//                .orElseThrow(() -> new ProfileNotFoundException("Profile not found"));
+//        p.setAvatarMediaId(mediaId);
+//    }
 
     @Transactional(readOnly = true)
     public PublicProfileResponse getPublicByUsername(String username) {

--- a/identity/src/main/resources/db/changelog/logs/030_profiles.xml
+++ b/identity/src/main/resources/db/changelog/logs/030_profiles.xml
@@ -30,8 +30,6 @@
 
             <column name="display_name" type="varchar(64)"/>
 
-            <column name="avatar_media_id" type="BIGINT"/>
-
             <column name="bio" type="varchar(500)"/>
 
             <column name="privacy" type="varchar(32)" defaultValue="PUBLIC">


### PR DESCRIPTION
- Commented user-avatar logic for later deletion because avatar ownership belongs to media.
- Removed avatar media ID from profile migrations and entity.
- Created separate public and protected security chains.
- Fixed MeResponseMapper ID mapping.

## Development links
Closes #72
Closes #73
Closes #77
Closes #122
Closes #123
Closes #124
Closes #153
Closes #154
Closes #155
Closes #156
Closes #160
Closes #178
Closes #389
Closes #397
Closes #398
Closes #399