### PR TITLE
Several fixes and changes:

### DIFF
--- a/identity/src/main/java/ua/nin/identity/auth/controller/AuthController.java
+++ b/identity/src/main/java/ua/nin/identity/auth/controller/AuthController.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import ua.nin.identity.auth.dto.*;
 import ua.nin.identity.auth.service.AuthService;
@@ -54,13 +55,15 @@ public class AuthController {
     }
 
     @PostMapping("/logout-all")
-    public ResponseEntity<Void> logoutAll() {
-        authService.logoutAll(); // userId береш із SecurityContext
+    public ResponseEntity<Void> logoutAll(Authentication authentication) {
+        long userId = Long.parseLong(authentication.getName());
+        authService.logoutAll(userId);
         return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/me")
-    public ResponseEntity<MeResponse> me() {
-        return ResponseEntity.ok(authService.me());
+    public ResponseEntity<MeResponse> me(Authentication authentication) {
+        long userId = Long.parseLong(authentication.getName());
+        return ResponseEntity.ok(authService.me(userId));
     }
 }

--- a/identity/src/main/java/ua/nin/identity/auth/controller/PasswordController.java
+++ b/identity/src/main/java/ua/nin/identity/auth/controller/PasswordController.java
@@ -3,6 +3,7 @@ package ua.nin.identity.auth.controller;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import ua.nin.identity.auth.dto.ChangePasswordRequest;
 import ua.nin.identity.auth.dto.ForgotPasswordRequest;
@@ -30,8 +31,9 @@ public class PasswordController {
     }
 
     @PostMapping("/change")
-    public ResponseEntity<Void> change(@Valid @RequestBody ChangePasswordRequest req) {
-        passwordService.change(req.currentPassword(), req.newPassword());
+    public ResponseEntity<Void> change(Authentication authentication, @Valid @RequestBody ChangePasswordRequest req) {
+        long userId = Long.parseLong(authentication.getName());
+        passwordService.change(userId, req.currentPassword(), req.newPassword());
         return ResponseEntity.noContent().build();
     }
 }

--- a/identity/src/main/java/ua/nin/identity/auth/mapper/MeResponseMapper.java
+++ b/identity/src/main/java/ua/nin/identity/auth/mapper/MeResponseMapper.java
@@ -9,7 +9,4 @@ import ua.nin.identity.auth.model.User;
 public interface MeResponseMapper {
     @Mapping(source = "id", target = "userId")
     MeResponse toDto(User user);
-
-    @Mapping(source = "userId", target = "id")
-    User toEntity(MeResponse meResponseDto);
 }

--- a/identity/src/main/java/ua/nin/identity/auth/service/AuthService.java
+++ b/identity/src/main/java/ua/nin/identity/auth/service/AuthService.java
@@ -19,7 +19,6 @@ import ua.nin.identity.auth.model.User;
 import ua.nin.identity.auth.repository.CredentialRepository;
 import ua.nin.identity.auth.repository.UserRepository;
 import ua.nin.common.util.StringHelperUtils;
-import ua.nin.identity.auth.util.SecurityUtils;
 import ua.nin.identity.profile.model.Privacy;
 import ua.nin.identity.profile.model.Profile;
 import ua.nin.identity.profile.repository.ProfileRepository;
@@ -167,15 +166,13 @@ public class AuthService {
 
     // ---------------- LOGOUT ALL ----------------
     @Transactional
-    public void logoutAll() {
-        long userId = SecurityUtils.currentUserId();
+    public void logoutAll(long userId) {
         refreshTokenService.revokeAllForUser(userId);
     }
 
     // ---------------- ME ----------------
     @Transactional(readOnly = true)
-    public MeResponse me() {
-        long userId = SecurityUtils.currentUserId();
+    public MeResponse me(long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundException("User not found"));
 

--- a/identity/src/main/java/ua/nin/identity/auth/service/PasswordService.java
+++ b/identity/src/main/java/ua/nin/identity/auth/service/PasswordService.java
@@ -15,7 +15,6 @@ import ua.nin.identity.auth.repository.CredentialRepository;
 import ua.nin.identity.auth.repository.PasswordResetTokenRepository;
 import ua.nin.identity.auth.repository.UserRepository;
 import ua.nin.common.util.StringHelperUtils;
-import ua.nin.identity.auth.util.SecurityUtils;
 import ua.nin.identity.auth.util.TimeTokenUtils;
 
 import java.time.Instant;
@@ -122,9 +121,7 @@ public class PasswordService {
      * Change password для залогіненого (access token required).
      */
     @Transactional
-    public void change(String currentPassword, String newPassword) {
-        long userId = SecurityUtils.currentUserId();
-
+    public void change(long userId, String currentPassword, String newPassword) {
         Credential cred = credentialRepository.findById(userId)
                 .orElseThrow(() -> new IllegalStateException("Credential missing"));
 

--- a/identity/src/main/java/ua/nin/identity/auth/util/SecurityUtils.java
+++ b/identity/src/main/java/ua/nin/identity/auth/util/SecurityUtils.java
@@ -4,10 +4,19 @@ import lombok.NoArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+// Left for later deletion
 @NoArgsConstructor
+@Deprecated(forRemoval = true)
+/**
+ * @deprecated
+ */
 public final class SecurityUtils {
 
-    // TODO: change to auth provider, so user id could be extracted from Authentication Principal in controller layer
+
+    @Deprecated
+    /**
+     * @deprecated (changed to Authentication (Principal) based JWT decoding in controllers
+     */
     public static long currentUserId() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         if (auth == null || auth.getPrincipal() == null) {

--- a/identity/src/main/java/ua/nin/identity/profile/controller/ProfileController.java
+++ b/identity/src/main/java/ua/nin/identity/profile/controller/ProfileController.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
-import ua.nin.identity.auth.util.SecurityUtils;
 import ua.nin.identity.profile.dto.*;
 import ua.nin.identity.profile.service.ProfileService;
 
@@ -19,22 +18,14 @@ public class ProfileController {
     @GetMapping("/me")
     public ResponseEntity<ProfileResponse> me(Authentication authentication) {
         long userId = Long.parseLong(authentication.getName());
-        //long userId = SecurityUtils.currentUserId();
         return ResponseEntity.ok(profileService.getMyProfile(userId));
     }
 
     @PatchMapping("/me/profile")
-    public ResponseEntity<ProfileResponse> update(@Valid @RequestBody UpdateProfileRequest req) {
-        long userId = SecurityUtils.currentUserId();
+    public ResponseEntity<ProfileResponse> update(Authentication authentication, @Valid @RequestBody UpdateProfileRequest req) {
+        long userId = Long.parseLong(authentication.getName());
         return ResponseEntity.ok(profileService.updateMyProfile(userId, req));
     }
-
-//    @PostMapping("/me/avatar")
-//    public ResponseEntity<Void> setAvatar(@Valid @RequestBody SetAvatarRequest req) {
-//        long userId = SecurityUtils.currentUserId();
-//        profileService.setAvatar(userId, req.mediaId());
-//        return ResponseEntity.noContent().build();
-//    }
 
     @GetMapping("/by-username/{username}")
     public ResponseEntity<PublicProfileResponse> publicByUsername(@PathVariable String username) {

--- a/identity/src/main/java/ua/nin/identity/profile/dto/ProfileResponse.java
+++ b/identity/src/main/java/ua/nin/identity/profile/dto/ProfileResponse.java
@@ -8,7 +8,6 @@ public record ProfileResponse(
         long userId,
         String username,
         String displayName,
-        Long avatarMediaId,
         String bio,
         Privacy privacy,
         String locale,

--- a/identity/src/main/java/ua/nin/identity/profile/dto/PublicProfileResponse.java
+++ b/identity/src/main/java/ua/nin/identity/profile/dto/PublicProfileResponse.java
@@ -3,6 +3,5 @@ package ua.nin.identity.profile.dto;
 public record PublicProfileResponse(
         String username,
         String displayName,
-        Long avatarMediaId,
         String bio
 ) {}

--- a/identity/src/main/java/ua/nin/identity/profile/mapper/ProfileResponseMapper.java
+++ b/identity/src/main/java/ua/nin/identity/profile/mapper/ProfileResponseMapper.java
@@ -7,6 +7,4 @@ import ua.nin.identity.profile.model.Profile;
 @Mapper(componentModel = "spring")
 public interface ProfileResponseMapper {
     ProfileResponse toDto(Profile profile);
-
-    Profile toEntity(ProfileResponse profileResponseDto);
 }

--- a/identity/src/main/java/ua/nin/identity/profile/mapper/PublicProfileResponseMapper.java
+++ b/identity/src/main/java/ua/nin/identity/profile/mapper/PublicProfileResponseMapper.java
@@ -7,6 +7,4 @@ import ua.nin.identity.profile.model.Profile;
 @Mapper(componentModel = "spring")
 public interface PublicProfileResponseMapper {
     PublicProfileResponse toDto(Profile profile);
-
-    Profile toEntity(PublicProfileResponse publicProfileResponseDto);
 }

--- a/media/src/main/java/ua/nin/media/dto/MediaMetaResponse.java
+++ b/media/src/main/java/ua/nin/media/dto/MediaMetaResponse.java
@@ -6,12 +6,12 @@ import java.time.Instant;
 
 public record MediaMetaResponse(
         long id,
-        Long ownerUserId,
         MediaKind kind,
         String contentType,
         String originalFilename,
         long sizeBytes,
         String sha256,
-        Instant createdAt
+        Instant createdAt,
+        Instant deletedAt
 ) {
 }

--- a/media/src/main/java/ua/nin/media/mapper/MediaMetaResponseMapper.java
+++ b/media/src/main/java/ua/nin/media/mapper/MediaMetaResponseMapper.java
@@ -7,6 +7,4 @@ import ua.nin.media.model.MediaAsset;
 @Mapper(componentModel = "spring")
 public interface MediaMetaResponseMapper {
     MediaMetaResponse toDto(MediaAsset mediaAsset);
-
-    MediaAsset toEntity(MediaMetaResponse mediaMetaResponseDto);
 }

--- a/views/src/main/java/ua/nin/views/mapper/ViewCountsResponseMapper.java
+++ b/views/src/main/java/ua/nin/views/mapper/ViewCountsResponseMapper.java
@@ -1,12 +1,15 @@
 package ua.nin.views.mapper;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import ua.nin.views.dto.ViewCountsResponse;
 import ua.nin.views.model.ViewCount;
 
 @Mapper(componentModel = "spring")
 public interface ViewCountsResponseMapper {
 
+    @Mapping(source = "id.targetType", target = "targetType")
+    @Mapping(source = "id.targetId", target = "targetId")
     ViewCountsResponse toDto(ViewCount viewCount);
 
 }


### PR DESCRIPTION
- Replaced token-based SecurityUtils usage with Spring Security Authentication in current-user flows.
- Removed the profile avatar endpoint because avatar ownership belongs to media.
- Updated media/profile response DTOs and one-way mappers.
- Fixed view response target ID mapping.
- Deprecated SecurityUtils.

## Development links
Closes #73
Closes #77
Closes #106
Closes #122
Closes #123
Closes #124
Closes #158
Closes #159
Closes #160
Closes #161
Closes #178
Closes #323
Closes #325
Closes #389
Closes #390
Closes #391
Closes #392
Closes #397
Closes #398
Closes #399
Closes #400