### PR TITLE
Identity cotroller oauth2 tests docs

### DIFF
--- a/app/src/main/resources/application.yaml
+++ b/app/src/main/resources/application.yaml
@@ -9,16 +9,16 @@ spring:
   # Datasource
   datasource:
     url: jdbc:postgresql://localhost:5431/NiN
-    username: postgres
-    password: postgres
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
     driver-class-name: org.postgresql.Driver
 
   # Liquibase
   liquibase:
     change-log: classpath:/db/changelog/db.changelog-master.xml
     enabled: true
-    user: postgres
-    password: postgres
+    user: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
 
   # Hibernate
   jpa:
@@ -39,6 +39,35 @@ spring:
       mail.smtp.auth: true
       mail.smtp.starttls.enable: true
       mail.debug: true
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            redirect-uri: http://localhost:8080/login/oauth2/code/google
+            scope: [openid, profile, email]
+            authorization-grant-type: authorization_code
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+#          github:
+#            redirect-uri: http://localhost:8080/login/oauth2/code/github
+#            client-id: ${GITHUB_CLIENT_ID}
+#            client-secret: ${GITHUB_CLIENT_SECRET}
+#            scope: read:user, user:email
+        provider:
+          google:
+            authorization-uri: https://accounts.google.com/o/oauth2/v2/auth
+            token-uri: https://oauth2.googleapis.com/token
+#          github:
+#            authorization-uri: https://github.com/login/oauth/authorize
+#            token-uri: https://github.com/login/oauth/access_token
+#            user-info-uri: https://api.github.com/user
+#            user-name-attribute: id
+  # Media config
+  servlet:
+    multipart:
+      max-file-size: 100MB
+      max-request-size: 120MB
 
 # Logging
 logging:
@@ -52,21 +81,17 @@ app:
     from: "NiN <nikchemno.nesmachno@gmail.com>"
   public-base-url: "http://localhost:8080"
 
-  # Media config
-  servlet:
-    multipart:
-      max-file-size: 100MB
-      max-request-size: 120MB
-
 # Identity token security
 jwt:
-  secret: "dev-secret-change-measdasdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
+  secret: ${JWT_SECRET}
 
 security:
   refresh:
     ttl-days: 14
-    bytes: 64
-    pepper: "CHANGE_ME_LONG_RANDOM"
+    secure: false
+  ott:
+    bytes: 32
+    pepper: ${OTT_PEPPER}
 
 # Media config
 media:

--- a/identity/pom.xml
+++ b/identity/pom.xml
@@ -31,10 +31,10 @@
             <artifactId>spring-boot-starter-mail</artifactId>
         </dependency>
 
-        <!--        <dependency>-->
-        <!--            <groupId>org.springframework.boot</groupId>-->
-        <!--            <artifactId>spring-boot-starter-oauth2-client</artifactId>-->
-        <!--        </dependency>-->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-client</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>

--- a/identity/src/main/java/ua/nin/identity/auth/config/SecurityConfig.java
+++ b/identity/src/main/java/ua/nin/identity/auth/config/SecurityConfig.java
@@ -15,7 +15,6 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
-import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
@@ -23,7 +22,10 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.security.web.util.matcher.OrRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
+import ua.nin.identity.auth.oauth2.state.CookieAuthorizationRequestRepository;
+import ua.nin.identity.auth.service.HttpCookieService;
 import ua.nin.identity.auth.service.OAuth2SuccessHandler;
+import ua.nin.identity.auth.util.TimeTokenUtils;
 
 import static ua.nin.common.constant.StringEndpoints.*;
 import static ua.nin.common.constant.AppConstant.ADMIN;
@@ -38,6 +40,8 @@ public class SecurityConfig {
     private final JwtDecoder jwtDecoder;
     private final JwtAuthenticationConverter jwtAuthenticationConverter;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final TimeTokenUtils timeTokenUtils;
+    private final HttpCookieService httpCookieService;
 
     @Bean
     public RequestMatcher publicMatcher() {
@@ -90,7 +94,7 @@ public class SecurityConfig {
 
                 .cors(Customizer.withDefaults())
                 .csrf(csrf -> csrf.disable())
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(a -> a.anyRequest().permitAll())
                 .oauth2Login(o -> o
                         .authorizationEndpoint(ae -> ae
@@ -161,6 +165,6 @@ public class SecurityConfig {
 
     @Bean
     public AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository() {
-        return new HttpSessionOAuth2AuthorizationRequestRepository();
+        return new CookieAuthorizationRequestRepository(timeTokenUtils, httpCookieService);
     }
 }

--- a/identity/src/main/java/ua/nin/identity/auth/config/SecurityConfig.java
+++ b/identity/src/main/java/ua/nin/identity/auth/config/SecurityConfig.java
@@ -14,12 +14,16 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.security.web.util.matcher.OrRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
+import ua.nin.identity.auth.service.OAuth2SuccessHandler;
 
 import static ua.nin.common.constant.StringEndpoints.*;
 import static ua.nin.common.constant.AppConstant.ADMIN;
@@ -33,6 +37,7 @@ public class SecurityConfig {
 
     private final JwtDecoder jwtDecoder;
     private final JwtAuthenticationConverter jwtAuthenticationConverter;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
 
     @Bean
     public RequestMatcher publicMatcher() {
@@ -63,6 +68,9 @@ public class SecurityConfig {
                 p.matcher(HttpMethod.GET, API_V1_VIEWS),
                 p.matcher(HttpMethod.POST, API_V1_VIEWS),
 
+                p.matcher(HttpMethod.GET, "/login/oauth2/code/**"),
+                p.matcher(HttpMethod.GET, "/oauth2/authorization/**"),
+
                 p.matcher(ACTUATOR),
                 p.matcher(V3_API_DOCS),
                 p.matcher(SWAGGER_UI),
@@ -82,8 +90,14 @@ public class SecurityConfig {
 
                 .cors(Customizer.withDefaults())
                 .csrf(csrf -> csrf.disable())
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(a -> a.anyRequest().permitAll());
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
+                .authorizeHttpRequests(a -> a.anyRequest().permitAll())
+                .oauth2Login(o -> o
+                        .authorizationEndpoint(ae -> ae
+                                .authorizationRequestRepository(authorizationRequestRepository())
+                        )
+                        .successHandler(oAuth2SuccessHandler)
+                );
 
         return http.build();
     }
@@ -143,5 +157,10 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder(12);
+    }
+
+    @Bean
+    public AuthorizationRequestRepository<OAuth2AuthorizationRequest> authorizationRequestRepository() {
+        return new HttpSessionOAuth2AuthorizationRequestRepository();
     }
 }

--- a/identity/src/main/java/ua/nin/identity/auth/dto/OAuth2UserDto.java
+++ b/identity/src/main/java/ua/nin/identity/auth/dto/OAuth2UserDto.java
@@ -1,0 +1,15 @@
+package ua.nin.identity.auth.dto;
+
+import lombok.Builder;
+import ua.nin.identity.auth.model.Provider;
+
+@Builder
+public record OAuth2UserDto(
+        Provider provider,
+        String providerId,
+        String email,
+        boolean emailVerified,
+        String name,
+        String picture
+) {
+}

--- a/identity/src/main/java/ua/nin/identity/auth/exception/exceptions/CookieDeserializeException.java
+++ b/identity/src/main/java/ua/nin/identity/auth/exception/exceptions/CookieDeserializeException.java
@@ -1,0 +1,11 @@
+package ua.nin.identity.auth.exception.exceptions;
+
+public class CookieDeserializeException extends RuntimeException {
+    public CookieDeserializeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public CookieDeserializeException(String message) {
+        super(message);
+    }
+}

--- a/identity/src/main/java/ua/nin/identity/auth/exception/exceptions/CookieSerializeException.java
+++ b/identity/src/main/java/ua/nin/identity/auth/exception/exceptions/CookieSerializeException.java
@@ -1,0 +1,7 @@
+package ua.nin.identity.auth.exception.exceptions;
+
+public class CookieSerializeException extends RuntimeException {
+    public CookieSerializeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/identity/src/main/java/ua/nin/identity/auth/model/OAuth2Identity.java
+++ b/identity/src/main/java/ua/nin/identity/auth/model/OAuth2Identity.java
@@ -1,0 +1,47 @@
+package ua.nin.identity.auth.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "oauth2_identities", schema = "authentication",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_oauth_user_id_provider", columnNames = {"user_id", "provider"}),
+                @UniqueConstraint(name = "uq_oauth_provider_subject", columnNames = {"provider", "subject"})
+        }
+)
+public class OAuth2Identity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "provider", nullable = false, length = 32)
+    @Enumerated(EnumType.STRING)
+    private Provider provider;
+
+    @Column(name = "subject", nullable = false, length = 255)
+    private String subject;
+
+    @Column(name = "email", length = 64)
+    private String email;
+
+    @Column(name = "email_verified", nullable = false)
+    private boolean emailVerified;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/identity/src/main/java/ua/nin/identity/auth/model/Provider.java
+++ b/identity/src/main/java/ua/nin/identity/auth/model/Provider.java
@@ -1,0 +1,5 @@
+package ua.nin.identity.auth.model;
+
+public enum Provider {
+    GOOGLE, GITHUB
+}

--- a/identity/src/main/java/ua/nin/identity/auth/oauth2/state/CookieAuthorizationRequestRepository.java
+++ b/identity/src/main/java/ua/nin/identity/auth/oauth2/state/CookieAuthorizationRequestRepository.java
@@ -1,0 +1,147 @@
+package ua.nin.identity.auth.oauth2.state;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.util.StringUtils;
+import ua.nin.identity.auth.exception.exceptions.CookieDeserializeException;
+import ua.nin.identity.auth.exception.exceptions.CookieSerializeException;
+import ua.nin.identity.auth.service.HttpCookieService;
+import ua.nin.identity.auth.util.TimeTokenUtils;
+
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.*;
+
+@RequiredArgsConstructor
+public class CookieAuthorizationRequestRepository implements
+        AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+    public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+    public static final String REDIRECT_URI_COOKIE_NAME = "redirect_uri";
+    public static final String OAUTH2_PATH = "/";
+
+    private static final int COOKIE_MAX_AGE_SECONDS = 180;
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final TimeTokenUtils timeTokenUtils;
+    private final HttpCookieService httpCookieService;
+
+    @Override
+    public void saveAuthorizationRequest(
+            OAuth2AuthorizationRequest authorizationRequest,
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        if (authorizationRequest == null) {
+            removeAuthorizationRequestCookies(response);
+            return;
+        }
+
+        String serializedRequest = serialize(authorizationRequest);
+        httpCookieService.addCookie(response,
+                OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME,
+                serializedRequest,
+                OAUTH2_PATH,
+                COOKIE_MAX_AGE_SECONDS
+        );
+
+        String redirectUri = (String) authorizationRequest.getAdditionalParameters()
+                .get(REDIRECT_URI_COOKIE_NAME);
+
+        if (StringUtils.hasText(redirectUri)) {
+            httpCookieService.addCookie(response, REDIRECT_URI_COOKIE_NAME, redirectUri, OAUTH2_PATH, COOKIE_MAX_AGE_SECONDS);
+        }
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        return httpCookieService.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+                .map(Cookie::getValue)
+                .map(cookieValue -> deserialize(cookieValue, OAuth2AuthorizationRequest.class))
+                .orElse(null);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        OAuth2AuthorizationRequest authorizationRequest = loadAuthorizationRequest(request);
+
+        removeAuthorizationRequestCookies(response);
+
+        return authorizationRequest;
+    }
+
+    public void removeAuthorizationRequestCookies(HttpServletResponse response) {
+        httpCookieService.deleteCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, OAUTH2_PATH);
+        httpCookieService.deleteCookie(response, REDIRECT_URI_COOKIE_NAME, OAUTH2_PATH);
+    }
+
+    public String serialize(Serializable object) {
+        try {
+            OAuth2AuthorizationRequest o = (OAuth2AuthorizationRequest) object;
+            String json = MAPPER.writeValueAsString(o);
+            String data = Base64.getUrlEncoder().withoutPadding()
+                    .encodeToString(json.getBytes(StandardCharsets.UTF_8));
+
+            String sig = timeTokenUtils.hmacSha256(data);
+            return data + "." + sig;
+        } catch (Exception e) {
+            throw new CookieSerializeException("Serialization failed.", e);
+        }
+    }
+
+    public <T> T deserialize(String value, Class<T> cls) {
+        try {
+            if (value == null || !value.contains(".")) {
+                throw new CookieDeserializeException("Invalid cookie format");
+            }
+
+            String[] parts = value.split("\\.");
+            if (parts.length != 2) {
+                throw new CookieDeserializeException("Invalid cookie structure");
+            }
+
+            String data = parts[0];
+            String sentSig = parts[1];
+
+            // 1. Перевіряємо підпис
+            String expectedSig = timeTokenUtils.hmacSha256(data);
+
+            if (!MessageDigest.isEqual(
+                    expectedSig.getBytes(StandardCharsets.UTF_8),
+                    sentSig.getBytes(StandardCharsets.UTF_8))) {
+                throw new CookieDeserializeException("Invalid HMAC signature");
+            }
+
+            // 2. Декодуємо payload
+            byte[] decoded = Base64.getUrlDecoder().decode(data);
+            Map<String, Object> p = MAPPER.readValue(decoded, new TypeReference<>() {});
+
+            @SuppressWarnings("unchecked")
+            OAuth2AuthorizationRequest result =
+                    OAuth2AuthorizationRequest.authorizationCode()
+                            .authorizationUri((String) p.get("authorizationUri"))
+                            .clientId((String) p.get("clientId"))
+                            .redirectUri((String) p.get("redirectUri"))
+                            .scopes(new HashSet<>((List<String>) p.get("scopes")))
+                            .state((String) p.get("state"))
+                            .attributes((Map<String, Object>) p.getOrDefault("attributes", Map.of()))
+                            .additionalParameters((Map<String, Object>) p.getOrDefault("additionalParameters", Map.of()))
+                            .build();
+
+            if (!cls.isInstance(result)) {
+                throw new CookieDeserializeException("Unexpected deserialized type: " + result.getClass(), null);
+            }
+            return cls.cast(result);
+        } catch (Exception e) {
+            throw new CookieDeserializeException("Deserialization failed", e);
+        }
+    }
+}

--- a/identity/src/main/java/ua/nin/identity/auth/repository/OAuth2IdentityRepository.java
+++ b/identity/src/main/java/ua/nin/identity/auth/repository/OAuth2IdentityRepository.java
@@ -1,0 +1,12 @@
+package ua.nin.identity.auth.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import ua.nin.identity.auth.model.OAuth2Identity;
+import ua.nin.identity.auth.model.Provider;
+
+import java.util.Optional;
+
+public interface OAuth2IdentityRepository extends JpaRepository<OAuth2Identity, Long> {
+    Optional<OAuth2Identity> findByProviderAndSubject(Provider provider, String subject);
+    boolean existsByUserIdAndProvider(Long userId, Provider provider);
+}

--- a/identity/src/main/java/ua/nin/identity/auth/service/HttpCookieService.java
+++ b/identity/src/main/java/ua/nin/identity/auth/service/HttpCookieService.java
@@ -1,6 +1,7 @@
 package ua.nin.identity.auth.service;
 
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
@@ -9,18 +10,20 @@ import org.springframework.stereotype.Service;
 public class HttpCookieService {
     public static final String REFRESH_COOKIE = "refresh_token";
 
-    // TODO: поставити собі ці значення з config
-    private static final int REFRESH_TTL_SECONDS = 60 * 60 * 24 * 14; // 14 days
-    // у dev можна false
-    private static final boolean HTTP_COOKIE_SECURE = false;
+    @Value("${security.refresh.ttl-days:14}")
+    private long refreshTtlDays;
+
+    @Value("${security.refresh.secure}")
+    private boolean httpCookieSecure = false;
 
     public void setRefreshCookie(HttpServletResponse response, String token) {
+        long refreshTtlSeconds = refreshTtlDays * 24 * 60 * 60;
 
         ResponseCookie cookie = ResponseCookie.from(REFRESH_COOKIE, token)
                 .httpOnly(true)
-                .secure(HTTP_COOKIE_SECURE)
+                .secure(httpCookieSecure)
                 .path("/api/v1/auth/refresh")
-                .maxAge(REFRESH_TTL_SECONDS)
+                .maxAge(refreshTtlSeconds)
                 .sameSite("Lax")
                 .build();
 
@@ -30,7 +33,7 @@ public class HttpCookieService {
     public void clearRefreshCookie(HttpServletResponse response) {
         ResponseCookie cookie = ResponseCookie.from(REFRESH_COOKIE, "")
                 .httpOnly(true)
-                .secure(HTTP_COOKIE_SECURE)
+                .secure(httpCookieSecure)
                 .path("/api/v1/auth/refresh")
                 .maxAge(0)
                 .sameSite("Lax")

--- a/identity/src/main/java/ua/nin/identity/auth/service/HttpCookieService.java
+++ b/identity/src/main/java/ua/nin/identity/auth/service/HttpCookieService.java
@@ -1,44 +1,70 @@
 package ua.nin.identity.auth.service;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 public class HttpCookieService {
     public static final String REFRESH_COOKIE = "refresh_token";
+    public static final String REFRESH_TOKEN_PATH = "/api/v1/auth/refresh";
 
-    @Value("${security.refresh.ttl-days:14}")
-    private long refreshTtlDays;
+    private final long refreshTtlDays;
+    private final boolean httpCookieSecure;
 
-    @Value("${security.refresh.secure}")
-    private boolean httpCookieSecure = false;
+    public HttpCookieService (@Value("${security.refresh.ttl-days:14}") Long refreshTtlDays,
+                              @Value("${security.refresh.secure}") Boolean httpCookieSecure) {
+        this.refreshTtlDays = refreshTtlDays;
+        this.httpCookieSecure = httpCookieSecure;
+    }
 
     public void setRefreshCookie(HttpServletResponse response, String token) {
         long refreshTtlSeconds = refreshTtlDays * 24 * 60 * 60;
 
-        ResponseCookie cookie = ResponseCookie.from(REFRESH_COOKIE, token)
-                .httpOnly(true)
-                .secure(httpCookieSecure)
-                .path("/api/v1/auth/refresh")
-                .maxAge(refreshTtlSeconds)
-                .sameSite("Lax")
-                .build();
-
-        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        addCookie(response, REFRESH_COOKIE, token, REFRESH_TOKEN_PATH, refreshTtlSeconds);
     }
 
     public void clearRefreshCookie(HttpServletResponse response) {
-        ResponseCookie cookie = ResponseCookie.from(REFRESH_COOKIE, "")
+        deleteCookie(response, REFRESH_COOKIE, REFRESH_TOKEN_PATH);
+    }
+
+    public Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(name)) {
+                    return Optional.of(cookie);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    public void addCookie(HttpServletResponse response, String name, String value, String path, long maxAge) {
+        ResponseCookie cookie = ResponseCookie.from(name, value)
                 .httpOnly(true)
                 .secure(httpCookieSecure)
-                .path("/api/v1/auth/refresh")
-                .maxAge(0)
+                .path(path)
                 .sameSite("Lax")
+                .maxAge(maxAge)
                 .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
 
+    public void deleteCookie(HttpServletResponse response, String name, String path) {
+        ResponseCookie cookie = ResponseCookie.from(name, "")
+                .httpOnly(true)
+                .secure(httpCookieSecure)
+                .path(path)
+                .sameSite("Lax")
+                .maxAge(0)
+                .build();
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 }

--- a/identity/src/main/java/ua/nin/identity/auth/service/OAuth2SuccessHandler.java
+++ b/identity/src/main/java/ua/nin/identity/auth/service/OAuth2SuccessHandler.java
@@ -1,0 +1,111 @@
+package ua.nin.identity.auth.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import ua.nin.identity.auth.dto.AuthResponse;
+import ua.nin.identity.auth.dto.IssueNewResult;
+import ua.nin.identity.auth.dto.OAuth2UserDto;
+import ua.nin.identity.auth.model.Provider;
+import ua.nin.identity.auth.model.User;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
+
+    private final Oauth2ProvisionService provisionService;
+    private final AccessTokenService accessTokenService;
+    private final RefreshTokenService refreshTokenService;
+    private final HttpCookieService cookieService;
+    private final ObjectMapper objectMapper;
+
+    @Value("${jwt.access-ttl-minutes:10}")
+    private long accessTtlMinutes;
+
+    @Override
+    public void onAuthenticationSuccess(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Authentication authentication) throws IOException {
+
+        // 1. Отримання провайдера
+        String provider;
+        OAuth2AuthenticationToken token  = (OAuth2AuthenticationToken) authentication;
+        provider = token.getAuthorizedClientRegistrationId();
+        //-------------------------------------- Other providers (GitHub for example) -----------------
+//        if (authentication instanceof OAuth2AuthenticationToken token) {
+//            provider = token.getAuthorizedClientRegistrationId();
+//        }
+
+        // 2. Отримання об'єкта Oidc і витягування даних користувача з нього
+        // sub (providerId), email, emailVerified, name, picture (link)
+
+//        DefaultOAuth2User principal = (DefaultOAuth2User) authentication.getPrincipal();
+//        Integer providerId = principal.getAttribute("id");
+//        String email = principal.getAttribute("email");
+//        String name = principal.getAttribute("name");
+//        String login = principal.getAttribute("login");
+//        String picture = principal.getAttribute("avatar_url");
+//-----------------------------------------------------------------------------------------------------------
+        OidcUser oidcUser = (OidcUser) authentication.getPrincipal();
+
+        String providerId = oidcUser.getSubject();
+        String email = oidcUser.getEmail();
+        Boolean emailVerified = oidcUser.getEmailVerified();
+        String name = oidcUser.getFullName();
+        String picture = oidcUser.getPicture();
+
+        OAuth2UserDto oAuth2UserDto = OAuth2UserDto.builder()
+                .provider(Provider.GOOGLE)
+                .providerId(providerId)
+                .email(email)
+                .emailVerified(emailVerified)
+                .name(name)
+                .picture(picture)
+                .build();
+
+        // 1) Створити/оновити користувача і прив'язку googleSub
+        User user = provisionService.provision(oAuth2UserDto);
+
+        //"User-Agent"
+        String userAgent = request.getHeader(HttpHeaders.USER_AGENT);
+        String ip = request.getRemoteAddr();
+        // 2) Випустити власні токени
+        // refresh issue (family + token)
+        IssueNewResult refresh = refreshTokenService.issueNew(user, userAgent, ip);
+
+        // access token
+        String role = user.getRole().name();
+        String access = accessTokenService.createAccessToken(user.getId(), List.of(role));
+
+        AuthResponse responseDto = new AuthResponse(
+                access,
+                "Bearer",
+                accessTtlMinutes * 60,
+                user.getId(),
+                role
+        );
+
+        cookieService.setRefreshCookie(response, refresh.rawRefreshToken());
+
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        objectMapper.writeValue(response.getOutputStream(), responseDto);
+        response.flushBuffer();
+    }
+}

--- a/identity/src/main/java/ua/nin/identity/auth/service/Oauth2ProvisionService.java
+++ b/identity/src/main/java/ua/nin/identity/auth/service/Oauth2ProvisionService.java
@@ -1,0 +1,155 @@
+package ua.nin.identity.auth.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import ua.nin.identity.auth.dto.AuthResponse;
+import ua.nin.identity.auth.dto.AuthResult;
+import ua.nin.identity.auth.dto.IssueNewResult;
+import ua.nin.identity.auth.dto.Oauth2UserDto;
+import ua.nin.identity.auth.exception.exceptions.UserNotFoundException;
+import ua.nin.identity.auth.model.OAuth2Identity;
+import ua.nin.identity.auth.model.Role;
+import ua.nin.identity.auth.model.Status;
+import ua.nin.identity.auth.model.User;
+import ua.nin.identity.auth.repository.CredentialRepository;
+import ua.nin.identity.auth.repository.OAuth2IdentityRepository;
+import ua.nin.identity.auth.repository.UserRepository;
+import ua.nin.identity.profile.model.Privacy;
+import ua.nin.identity.profile.model.Profile;
+import ua.nin.identity.profile.repository.ProfileRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class Oauth2ProvisionService {
+
+    private final UserRepository userRepository;
+    private final ProfileRepository profileRepository;
+    private final OAuth2IdentityRepository oAuth2IdentityRepository;
+
+    private final AccessTokenService accessTokenService;
+    private final RefreshTokenService refreshTokenService;
+
+    @Value("${jwt.access-ttl-minutes:10}")
+    private long accessTtlMinutes;
+
+    /*
+    public class GoogleUserDto {
+        private String provider
+        private String googleProviderId;
+        private String email;
+        private Boolean emailVerified;
+        private String name;
+        private String picture;
+    }
+     */
+
+
+    @Transactional
+    public AuthResult provisionUser(Oauth2UserDto dto, String userAgent, String ip) {
+        Optional<OAuth2Identity> linkedUserIdentity = oAuth2IdentityRepository.findByProviderAndSubject(dto.provider(), dto.providerId());
+
+        if (linkedUserIdentity.isPresent()) {
+            OAuth2Identity identity = linkedUserIdentity.get();
+            updateUserProfile(identity, dto);
+            User user = userRepository.findByEmail(dto.email()).get();
+            return issueTokens(user, userAgent, ip);
+        }
+
+        Optional<User> userByEmail = userRepository.findByEmail(dto.email());
+
+        if (userByEmail.isPresent()) {
+            User user = userByEmail.get();
+            linkOauth2Provider(user, dto);
+            return issueTokens(user, userAgent, ip);
+        }
+
+        User newUser = createNewOauth2Identity(dto);
+        return issueTokens(newUser, userAgent, ip);
+    }
+
+    private void updateUserProfile(OAuth2Identity identity, Oauth2UserDto dto) {
+        identity.setEmailVerified(dto.emailVerified());
+        oAuth2IdentityRepository.save(identity);
+//        if (dto.getPicture() != null && !dto.getPicture().isEmpty()) {
+//            user.setProfilePicturePath(dto.getPicture());
+//        }
+    }
+
+    private void linkOauth2Provider(User user, Oauth2UserDto dto) {
+        OAuth2Identity oAuth2Identity = OAuth2Identity.builder()
+                .userId(user.getId())
+                .provider(dto.provider())
+                .subject(dto.providerId())
+                .email(dto.email())
+                .emailVerified(dto.emailVerified())
+                .build();
+        oAuth2IdentityRepository.save(oAuth2Identity);
+
+        if (user.getStatus().equals(Status.PENDING_EMAIL) && dto.emailVerified()) {
+            user.setStatus(Status.ACTIVE);
+            userRepository.save(user);
+        }
+
+//        if (user.getProfilePicturePath() == null || user.getProfilePicturePath().isEmpty()) {
+//            user.setProfilePicturePath(dto.getPicture());
+//        }
+    }
+
+    private User createNewOauth2Identity(Oauth2UserDto dto) {
+        User user = User.builder()
+                .email(dto.email())
+                .status(dto.emailVerified()
+                        ? Status.ACTIVE
+                        : Status.PENDING_EMAIL)
+                .role(Role.USER)
+                .build();
+        user = userRepository.save(user);
+
+        OAuth2Identity oAuth2Identity = OAuth2Identity.builder()
+                .userId(user.getId())
+                .provider(dto.provider())
+                .subject(dto.providerId())
+                .email(dto.email())
+                .emailVerified(dto.emailVerified())
+                .build();
+        oAuth2IdentityRepository.save(oAuth2Identity);
+
+        Profile profile = Profile.builder()
+                .user(user)
+                .username(dto.name())
+                .displayName(dto.name())
+                .privacy(Privacy.PUBLIC)
+                .build();
+        profileRepository.save(profile);
+
+        return user;
+    }
+
+    private AuthResult issueTokens(User user, String userAgent, String ip) {
+        // refresh issue (family + token)
+        IssueNewResult refresh = refreshTokenService.issueNew(user, userAgent, ip);
+
+        // access token
+        String role = user.getRole().name();
+        String access = accessTokenService.createAccessToken(user.getId(), List.of(role));
+
+        AuthResponse response = new AuthResponse(
+                access,
+                "Bearer",
+                accessTtlMinutes * 60,
+                user.getId(),
+                role
+        );
+
+        return new AuthResult(response, refresh.rawRefreshToken());
+    }
+}

--- a/identity/src/main/java/ua/nin/identity/auth/service/Oauth2ProvisionService.java
+++ b/identity/src/main/java/ua/nin/identity/auth/service/Oauth2ProvisionService.java
@@ -3,27 +3,20 @@ package ua.nin.identity.auth.service;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import ua.nin.identity.auth.dto.AuthResponse;
-import ua.nin.identity.auth.dto.AuthResult;
-import ua.nin.identity.auth.dto.IssueNewResult;
-import ua.nin.identity.auth.dto.Oauth2UserDto;
-import ua.nin.identity.auth.exception.exceptions.UserNotFoundException;
+import ua.nin.identity.auth.dto.OAuth2UserDto;
+import ua.nin.identity.auth.exception.exceptions.NotFoundException;
 import ua.nin.identity.auth.model.OAuth2Identity;
 import ua.nin.identity.auth.model.Role;
 import ua.nin.identity.auth.model.Status;
 import ua.nin.identity.auth.model.User;
-import ua.nin.identity.auth.repository.CredentialRepository;
 import ua.nin.identity.auth.repository.OAuth2IdentityRepository;
 import ua.nin.identity.auth.repository.UserRepository;
 import ua.nin.identity.profile.model.Privacy;
 import ua.nin.identity.profile.model.Profile;
 import ua.nin.identity.profile.repository.ProfileRepository;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
+import java.time.Instant;
 import java.util.UUID;
 
 @Service
@@ -33,123 +26,118 @@ public class Oauth2ProvisionService {
 
     private final UserRepository userRepository;
     private final ProfileRepository profileRepository;
-    private final OAuth2IdentityRepository oAuth2IdentityRepository;
-
-    private final AccessTokenService accessTokenService;
-    private final RefreshTokenService refreshTokenService;
-
-    @Value("${jwt.access-ttl-minutes:10}")
-    private long accessTtlMinutes;
-
-    /*
-    public class GoogleUserDto {
-        private String provider
-        private String googleProviderId;
-        private String email;
-        private Boolean emailVerified;
-        private String name;
-        private String picture;
-    }
-     */
-
+    private final OAuth2IdentityRepository identityRepository;
 
     @Transactional
-    public AuthResult provisionUser(Oauth2UserDto dto, String userAgent, String ip) {
-        Optional<OAuth2Identity> linkedUserIdentity = oAuth2IdentityRepository.findByProviderAndSubject(dto.provider(), dto.providerId());
+    public User provision(OAuth2UserDto dto) {
+        Instant now = Instant.now();
 
-        if (linkedUserIdentity.isPresent()) {
-            OAuth2Identity identity = linkedUserIdentity.get();
-            updateUserProfile(identity, dto);
-            User user = userRepository.findByEmail(dto.email()).get();
-            return issueTokens(user, userAgent, ip);
+        // 1) by provider+subject
+        var existingIdentity = identityRepository.findByProviderAndSubject(dto.provider(), dto.providerId());
+        if (existingIdentity.isPresent()) {
+            Long userId = existingIdentity.get().getUserId();
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new NotFoundException("User not found: " + userId));
+            touchIdentity(existingIdentity.get(), dto, now);
+            return user;
         }
 
-        Optional<User> userByEmail = userRepository.findByEmail(dto.email());
-
-        if (userByEmail.isPresent()) {
-            User user = userByEmail.get();
-            linkOauth2Provider(user, dto);
-            return issueTokens(user, userAgent, ip);
+        // 2) by email (only if verified and non-null)
+        User user = null;
+        if (dto.email() != null && dto.emailVerified()) {
+            user = userRepository.findByEmail(dto.email()).orElse(null);
         }
 
-        User newUser = createNewOauth2Identity(dto);
-        return issueTokens(newUser, userAgent, ip);
-    }
+        // 3) create if not exists
+        if (user == null) {
+            user = createUser(dto, now);
+            user = userRepository.save(user);
 
-    private void updateUserProfile(OAuth2Identity identity, Oauth2UserDto dto) {
-        identity.setEmailVerified(dto.emailVerified());
-        oAuth2IdentityRepository.save(identity);
-//        if (dto.getPicture() != null && !dto.getPicture().isEmpty()) {
-//            user.setProfilePicturePath(dto.getPicture());
-//        }
-    }
+            // create profile if missing
+            createProfileIfMissing(user, dto, now);
+        } else {
+            // if was PENDING_EMAIL, but now is verified through OAuth — do ACTIVE
+            if (Status.PENDING_EMAIL.equals(user.getStatus()) && dto.emailVerified()) {
+                user.setStatus(Status.ACTIVE);
+                user.setUpdatedAt(now);
+                userRepository.save(user);
+            }
+            createProfileIfMissing(user, dto, now);
+        }
 
-    private void linkOauth2Provider(User user, Oauth2UserDto dto) {
-        OAuth2Identity oAuth2Identity = OAuth2Identity.builder()
+        // 4) link identity
+        OAuth2Identity identity = OAuth2Identity.builder()
                 .userId(user.getId())
                 .provider(dto.provider())
                 .subject(dto.providerId())
                 .email(dto.email())
                 .emailVerified(dto.emailVerified())
+                .createdAt(now)
+                .updatedAt(now)
                 .build();
-        oAuth2IdentityRepository.save(oAuth2Identity);
 
-        if (user.getStatus().equals(Status.PENDING_EMAIL) && dto.emailVerified()) {
-            user.setStatus(Status.ACTIVE);
-            userRepository.save(user);
-        }
-
-//        if (user.getProfilePicturePath() == null || user.getProfilePicturePath().isEmpty()) {
-//            user.setProfilePicturePath(dto.getPicture());
-//        }
-    }
-
-    private User createNewOauth2Identity(Oauth2UserDto dto) {
-        User user = User.builder()
-                .email(dto.email())
-                .status(dto.emailVerified()
-                        ? Status.ACTIVE
-                        : Status.PENDING_EMAIL)
-                .role(Role.USER)
-                .build();
-        user = userRepository.save(user);
-
-        OAuth2Identity oAuth2Identity = OAuth2Identity.builder()
-                .userId(user.getId())
-                .provider(dto.provider())
-                .subject(dto.providerId())
-                .email(dto.email())
-                .emailVerified(dto.emailVerified())
-                .build();
-        oAuth2IdentityRepository.save(oAuth2Identity);
-
-        Profile profile = Profile.builder()
-                .user(user)
-                .username(dto.name())
-                .displayName(dto.name())
-                .privacy(Privacy.PUBLIC)
-                .build();
-        profileRepository.save(profile);
-
+        identityRepository.save(identity);
         return user;
     }
 
-    private AuthResult issueTokens(User user, String userAgent, String ip) {
-        // refresh issue (family + token)
-        IssueNewResult refresh = refreshTokenService.issueNew(user, userAgent, ip);
+    private void touchIdentity(OAuth2Identity identity, OAuth2UserDto dto, Instant now) {
+        identity.setEmail(dto.email());
+        identity.setEmailVerified(dto.emailVerified());
+        identity.setUpdatedAt(now);
+        identityRepository.save(identity);
+    }
 
-        // access token
-        String role = user.getRole().name();
-        String access = accessTokenService.createAccessToken(user.getId(), List.of(role));
+    private User createUser(OAuth2UserDto dto, Instant now) {
+        User u = new User();
+        u.setEmail(dto.email() != null ? dto.email() : ("no-email@" + dto.provider().name().toLowerCase() + ".local"));
+        u.setRole(Role.USER);
+        u.setStatus(dto.emailVerified() ? Status.ACTIVE : Status.PENDING_EMAIL);
+        u.setCreatedAt(now);
+        u.setUpdatedAt(now);
+        u.setLastLoginAt(now);
+        return u;
+    }
 
-        AuthResponse response = new AuthResponse(
-                access,
-                "Bearer",
-                accessTtlMinutes * 60,
-                user.getId(),
-                role
-        );
+    private void createProfileIfMissing(User user, OAuth2UserDto dto, Instant now) {
+        if (profileRepository.findByUserId(user.getId()).isPresent()) return;
 
-        return new AuthResult(response, refresh.rawRefreshToken());
+        String base = deriveUsername(dto);
+        String username = uniqueUsername(base);
+
+        Profile p = new Profile();
+        p.setUser(user);
+        p.setUsername(username);
+        p.setDisplayName(dto.name());
+        p.setBio(null);
+        p.setPrivacy(Privacy.PUBLIC);
+        p.setLocale(null);
+        p.setTimezone(null);
+        p.setCreatedAt(now);
+        p.setUpdatedAt(now);
+
+        profileRepository.saveAndFlush(p);
+    }
+
+    private String deriveUsername(OAuth2UserDto info) {
+        if (info.email() != null && info.email().contains("@")) {
+            return info.email().substring(0, info.email().indexOf('@')).replaceAll("[^a-zA-Z0-9_.]", "_");
+        }
+        if (info.name() != null && !info.name().isBlank()) {
+            return info.name().trim().replaceAll("\\s+", "_").replaceAll("[^a-zA-Z0-9_.]", "_");
+        }
+        return info.provider().name().toLowerCase() + "_user";
+    }
+
+    private String uniqueUsername(String base) {
+        String b = base.length() > 32
+                ? base.substring(0, 32)
+                : base;
+        if (!profileRepository.existsByUsername(b)) return b;
+
+        String candidate = b + "_" + UUID.randomUUID();
+        candidate = candidate.length() > 64 ? candidate.substring(0, 64) : candidate;
+        if (!profileRepository.existsByUsername(candidate)) return candidate;
+
+        throw new IllegalStateException("Failed to allocate unique username.");
     }
 }

--- a/identity/src/main/java/ua/nin/identity/auth/service/RefreshTokenService.java
+++ b/identity/src/main/java/ua/nin/identity/auth/service/RefreshTokenService.java
@@ -19,6 +19,8 @@ import ua.nin.identity.auth.util.TimeTokenUtils;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
+import static ua.nin.common.util.StringHelperUtils.normalizeAndTruncate;
+
 @Service
 @RequiredArgsConstructor
 public class RefreshTokenService {
@@ -47,7 +49,7 @@ public class RefreshTokenService {
 
         RefreshTokenFamily family = RefreshTokenFamily.builder()
                 .user(user)
-                .userAgent(trimOrNull(userAgent, 512))
+                .userAgent(normalizeAndTruncate(userAgent, 512))
                 .ip(InetAddressUtils.parseIp(ip))
                 .build();
 
@@ -129,7 +131,7 @@ public class RefreshTokenService {
         refreshTokenRepository.save(current);
 
         // 6) оновлюємо метадані family
-        familyRepository.touch(family.getId(), now, trimOrNull(userAgent, 512), InetAddressUtils.parseIp(ip));
+        familyRepository.touch(family.getId(), now, normalizeAndTruncate(userAgent, 512), InetAddressUtils.parseIp(ip));
 
         return new RefreshIssueResult(newRaw, family.getId());
     }
@@ -175,14 +177,5 @@ public class RefreshTokenService {
     private void revokeFamilyInternal(long familyId, Instant now) {
         familyRepository.revokeFamily(familyId, now);
         refreshTokenRepository.revokeAllInFamily(familyId, now);
-    }
-
-    // ---- helpers ----
-
-    private static String trimOrNull(String s, int max) {
-        if (s == null) return null;
-        String t = s.trim();
-        if (t.isEmpty()) return null;
-        return t.length() <= max ? t : t.substring(0, max);
     }
 }

--- a/identity/src/main/java/ua/nin/identity/auth/util/TimeTokenUtils.java
+++ b/identity/src/main/java/ua/nin/identity/auth/util/TimeTokenUtils.java
@@ -1,26 +1,34 @@
 package ua.nin.identity.auth.util;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.codec.Hex;
 import org.springframework.stereotype.Component;
 
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.util.Base64;
 
 @Component
-@RequiredArgsConstructor
 public class TimeTokenUtils {
 
     private final SecureRandom secureRandom;
+    private final int bytes;
+    private final String pepper;
+    private final String hmacSecret;
 
-    @Value("${security.ott.bytes:32}")
-    private int bytes;
+    public TimeTokenUtils(SecureRandom secureRandom,
+                          @Value("${security.ott.bytes:32}") int bytes,
+                          @Value("${security.ott.pepper:CHANGE_ME}") String pepper,
+                          @Value("${jwt.secret}") String hmacSecret) {
+        this.secureRandom = secureRandom;
+        this.bytes = bytes;
+        this.pepper = pepper;
+        this.hmacSecret = hmacSecret;
+    }
 
-    @Value("${security.ott.pepper:CHANGE_ME}")
-    private String pepper;
 
     public String generateRawToken() {
         byte[] buf = new byte[bytes];
@@ -39,6 +47,17 @@ public class TimeTokenUtils {
             byte[] input = (raw + "." + pepper).getBytes(StandardCharsets.UTF_8);
             byte[] digest = md.digest(input);
             return new String(Hex.encode(digest));
+        } catch (Exception e) {
+            throw new IllegalStateException("Cannot hash token", e);
+        }
+    }
+
+    public String hmacSha256(String data) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(hmacSecret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            byte[] out = mac.doFinal(data.getBytes(StandardCharsets.UTF_8));
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(out);
         } catch (Exception e) {
             throw new IllegalStateException("Cannot hash token", e);
         }

--- a/identity/src/main/java/ua/nin/identity/auth/util/TimeTokenUtils.java
+++ b/identity/src/main/java/ua/nin/identity/auth/util/TimeTokenUtils.java
@@ -16,10 +16,10 @@ public class TimeTokenUtils {
 
     private final SecureRandom secureRandom;
 
-    @Value("${security.ott.bytes:48}")
+    @Value("${security.ott.bytes:32}")
     private int bytes;
 
-    @Value("${security.refresh.pepper:CHANGE_ME}")
+    @Value("${security.ott.pepper:CHANGE_ME}")
     private String pepper;
 
     public String generateRawToken() {

--- a/identity/src/main/resources/db/changelog/db.identity-changelog-master.xml
+++ b/identity/src/main/resources/db/changelog/db.identity-changelog-master.xml
@@ -13,6 +13,7 @@
     <include file="/db/changelog/logs/050_refresh_tokens.xml"/>
     <include file="/db/changelog/logs/060_email_verification_tokens.xml"/>
     <include file="/db/changelog/logs/070_password_reset_tokens.xml"/>
+    <include file="/db/changelog/logs/080_oauth2_identities.xml"/>
 
 </databaseChangeLog>
 

--- a/identity/src/main/resources/db/changelog/logs/080_oauth2_identities.xml
+++ b/identity/src/main/resources/db/changelog/logs/080_oauth2_identities.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.25.xsd">
+
+    <changeSet id="080-create-oauth2-identities" author="Lain (Ivan)">
+        <createTable tableName="oauth2_identities" schemaName="authentication">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+
+            <column name="user_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="provider" type="varchar(32)">
+                <constraints nullable="false"
+                             checkConstraint="provider IN ('GOOGLE','GITHUB')"/>
+            </column>
+
+            <column name="subject" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="email" type="varchar(64)"/>
+
+            <column name="email_verified" type="boolean" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="created_at" type="timestamptz" defaultValueComputed="now()">
+                <constraints nullable="false"/>
+            </column>
+
+            <column name="updated_at" type="timestamptz" defaultValueComputed="now()">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint
+                baseTableSchemaName="authentication"
+                baseTableName="oauth2_identities"
+                baseColumnNames="user_id"
+                referencedTableSchemaName="authentication"
+                referencedTableName="users"
+                referencedColumnNames="id"
+                constraintName="fk_oauth2_identities_user"
+                onDelete="CASCADE"/>
+
+        <addUniqueConstraint schemaName="authentication" tableName="oauth2_identities"
+                             columnNames="user_id,provider"
+                             constraintName="uq_oauth_user_id_provider"/>
+
+        <addUniqueConstraint schemaName="authentication" tableName="oauth2_identities"
+                             columnNames="provider,subject"
+                             constraintName="uq_oauth_provider_subject"/>
+
+        <createIndex schemaName="authentication" tableName="oauth2_identities" indexName="idx_oauth2_identities_user_id">
+            <column name="user_id"/>
+        </createIndex>
+
+        <rollback>
+            <dropTable schemaName="authentication" tableName="oauth2_identities"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/identity/src/test/java/ua/nin/identity/auth/config/PublicMatcherParameterizedTest.java
+++ b/identity/src/test/java/ua/nin/identity/auth/config/PublicMatcherParameterizedTest.java
@@ -8,7 +8,9 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.util.matcher.RequestMatcher;
+import ua.nin.identity.auth.service.HttpCookieService;
 import ua.nin.identity.auth.service.OAuth2SuccessHandler;
+import ua.nin.identity.auth.util.TimeTokenUtils;
 
 import java.util.stream.Stream;
 
@@ -23,12 +25,18 @@ class PublicMatcherParameterizedTest {
     private JwtAuthenticationConverter jwtAuthenticationConverter;
     @Mock
     private OAuth2SuccessHandler oAuth2SuccessHandler;
+    @Mock
+    private TimeTokenUtils timeTokenUtils;
+    @Mock
+    private HttpCookieService httpCookieService;
 
     // publicMatcher() не використовує jwtDecoder/converter, тому можна надати заглушки.
     private final RequestMatcher publicMatcher = new SecurityConfig(
             jwtDecoder,
             jwtAuthenticationConverter,
-            oAuth2SuccessHandler
+            oAuth2SuccessHandler,
+            timeTokenUtils,
+            httpCookieService
     ).publicMatcher();
 
     // ---------- helpers ----------

--- a/identity/src/test/java/ua/nin/identity/auth/config/PublicMatcherParameterizedTest.java
+++ b/identity/src/test/java/ua/nin/identity/auth/config/PublicMatcherParameterizedTest.java
@@ -2,11 +2,13 @@ package ua.nin.identity.auth.config;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
 import org.springframework.http.HttpMethod;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.util.matcher.RequestMatcher;
+import ua.nin.identity.auth.service.OAuth2SuccessHandler;
 
 import java.util.stream.Stream;
 
@@ -15,10 +17,18 @@ import static ua.nin.common.constant.StringEndpoints.*;
 
 class PublicMatcherParameterizedTest {
 
+    @Mock
+    private JwtDecoder jwtDecoder;
+    @Mock
+    private JwtAuthenticationConverter jwtAuthenticationConverter;
+    @Mock
+    private OAuth2SuccessHandler oAuth2SuccessHandler;
+
     // publicMatcher() не використовує jwtDecoder/converter, тому можна надати заглушки.
     private final RequestMatcher publicMatcher = new SecurityConfig(
-            (JwtDecoder) token -> { throw new UnsupportedOperationException(); },
-            new JwtAuthenticationConverter()
+            jwtDecoder,
+            jwtAuthenticationConverter,
+            oAuth2SuccessHandler
     ).publicMatcher();
 
     // ---------- helpers ----------
@@ -61,6 +71,10 @@ class PublicMatcherParameterizedTest {
                 // views
                 c(HttpMethod.GET, API_V1_VIEWS, "/api/v1/views"),
                 c(HttpMethod.POST, API_V1_VIEWS, "/api/v1/views"),
+
+                // OAuth2
+                c(HttpMethod.GET, "/login/oauth2/code/**", "/login/oauth2/code/google"),
+                c(HttpMethod.GET, "/oauth2/authorization/**", "/oauth2/authorization/google"),
 
                 // actuator + swagger
                 c(null, ACTUATOR, "/actuator/health"),

--- a/identity/src/test/java/ua/nin/identity/auth/controller/AuthControllerTest.java
+++ b/identity/src/test/java/ua/nin/identity/auth/controller/AuthControllerTest.java
@@ -36,7 +36,7 @@ class AuthControllerTest {
     private AuthService authService;
 
     @Spy
-    private HttpCookieService httpCookieService = new HttpCookieService();
+    private HttpCookieService httpCookieService = new HttpCookieService(14L, false);
 
     @InjectMocks
     private AuthController authController;

--- a/identity/src/test/java/ua/nin/identity/auth/oauth2/state/CookieAuthorizationRequestRepositoryTest.java
+++ b/identity/src/test/java/ua/nin/identity/auth/oauth2/state/CookieAuthorizationRequestRepositoryTest.java
@@ -1,0 +1,234 @@
+package ua.nin.identity.auth.oauth2.state;
+
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import ua.nin.identity.auth.exception.exceptions.CookieDeserializeException;
+import ua.nin.identity.auth.exception.exceptions.CookieSerializeException;
+import ua.nin.identity.auth.service.HttpCookieService;
+import ua.nin.identity.auth.util.TimeTokenUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static ua.nin.identity.auth.oauth2.state.CookieAuthorizationRequestRepository.*;
+
+@ExtendWith(MockitoExtension.class)
+class CookieAuthorizationRequestRepositoryTest {
+
+    @Mock private TimeTokenUtils timeTokenUtils;
+    @Mock private HttpCookieService httpCookieService;
+
+    @Captor private ArgumentCaptor<String> cookieValueCaptor;
+
+    private CookieAuthorizationRequestRepository repo;
+
+    @BeforeEach
+    void setUp() {
+        repo = new CookieAuthorizationRequestRepository(timeTokenUtils, httpCookieService);
+    }
+
+    // Стабим только там, где реально вызывается hmacSha256()
+    private void stubDeterministicHmac() {
+        when(timeTokenUtils.hmacSha256(anyString()))
+                .thenAnswer(inv -> sha256Base64Url(inv.getArgument(0, String.class)));
+    }
+
+    @Test
+    void saveAuthorizationRequest_shouldSetAuthRequestCookie_andRedirectCookie() {
+        stubDeterministicHmac();
+
+        var req = new MockHttpServletRequest();
+        var resp = new MockHttpServletResponse();
+
+        OAuth2AuthorizationRequest authReq = sampleAuthRequestWithRedirect("https://front/app/after");
+
+        repo.saveAuthorizationRequest(authReq, req, resp);
+
+        verify(httpCookieService).addCookie(
+                eq(resp),
+                eq(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME),
+                cookieValueCaptor.capture(),
+                eq(OAUTH2_PATH),
+                eq(180L) // <-- ВАЖНО: long
+        );
+
+        String serialized = cookieValueCaptor.getValue();
+        assertThat(serialized).contains(".");
+        assertThat(serialized.split("\\.")).hasSize(2);
+
+        verify(httpCookieService).addCookie(
+                eq(resp),
+                eq(REDIRECT_URI_COOKIE_NAME),
+                eq("https://front/app/after"),
+                eq(OAUTH2_PATH),
+                eq(180L) // <-- long
+        );
+
+        verify(httpCookieService, never()).deleteCookie(any(), anyString(), anyString());
+    }
+
+    @Test
+    void saveAuthorizationRequest_whenNull_shouldDeleteCookies() {
+        var req = new MockHttpServletRequest();
+        var resp = new MockHttpServletResponse();
+
+        repo.saveAuthorizationRequest(null, req, resp);
+
+        verify(httpCookieService).deleteCookie(eq(resp), eq(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME), eq(OAUTH2_PATH));
+        verify(httpCookieService).deleteCookie(eq(resp), eq(REDIRECT_URI_COOKIE_NAME), eq(OAUTH2_PATH));
+        verify(httpCookieService, never()).addCookie(any(), anyString(), anyString(), anyString(), anyLong());
+
+        // и вот тут hmacSha256 НЕ вызывается -> поэтому не надо его стабать в setUp()
+        verifyNoInteractions(timeTokenUtils);
+    }
+
+    @Test
+    void loadAuthorizationRequest_shouldReturnDeserializedRequest() {
+        stubDeterministicHmac();
+
+        var req = new MockHttpServletRequest();
+
+        OAuth2AuthorizationRequest original = sampleAuthRequestWithRedirect("https://front/app/after");
+        String serialized = repo.serialize(original);
+
+        when(httpCookieService.getCookie(eq(req), eq(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)))
+                .thenReturn(Optional.of(new Cookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, serialized)));
+
+        OAuth2AuthorizationRequest loaded = repo.loadAuthorizationRequest(req);
+
+        assertThat(loaded).isNotNull();
+        assertThat(loaded.getAuthorizationUri()).isEqualTo(original.getAuthorizationUri());
+        assertThat(loaded.getClientId()).isEqualTo(original.getClientId());
+        assertThat(loaded.getRedirectUri()).isEqualTo(original.getRedirectUri());
+        assertThat(loaded.getState()).isEqualTo(original.getState());
+        assertThat(loaded.getScopes()).containsExactlyInAnyOrderElementsOf(original.getScopes());
+
+        assertThat(loaded.getAdditionalParameters())
+                .containsEntry(REDIRECT_URI_COOKIE_NAME, "https://front/app/after")
+                .containsEntry("access_type", "offline");
+
+        assertThat(loaded.getAttributes()).containsEntry("k", "v");
+    }
+
+    @Test
+    void loadAuthorizationRequest_whenNoCookie_shouldReturnNull() {
+        var req = new MockHttpServletRequest();
+
+        when(httpCookieService.getCookie(eq(req), eq(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)))
+                .thenReturn(Optional.empty());
+
+        assertThat(repo.loadAuthorizationRequest(req)).isNull();
+        verifyNoInteractions(timeTokenUtils);
+    }
+
+    @Test
+    void removeAuthorizationRequest_shouldReturnRequest_andDeleteCookies() {
+        stubDeterministicHmac();
+
+        var req = new MockHttpServletRequest();
+        var resp = new MockHttpServletResponse();
+
+        OAuth2AuthorizationRequest original = sampleAuthRequestWithRedirect("https://front/app/after");
+        String serialized = repo.serialize(original);
+
+        when(httpCookieService.getCookie(eq(req), eq(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)))
+                .thenReturn(Optional.of(new Cookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, serialized)));
+
+        OAuth2AuthorizationRequest removed = repo.removeAuthorizationRequest(req, resp);
+
+        assertThat(removed).isNotNull();
+        assertThat(removed.getClientId()).isEqualTo(original.getClientId());
+
+        verify(httpCookieService).deleteCookie(eq(resp), eq(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME), eq(OAUTH2_PATH));
+        verify(httpCookieService).deleteCookie(eq(resp), eq(REDIRECT_URI_COOKIE_NAME), eq(OAUTH2_PATH));
+    }
+
+    @Test
+    void deserialize_whenInvalidFormat_shouldThrowCookieDeserializeException() {
+        assertThatThrownBy(() -> repo.deserialize("no-dot-here", OAuth2AuthorizationRequest.class))
+                .isInstanceOf(CookieDeserializeException.class);
+
+        verifyNoInteractions(timeTokenUtils);
+    }
+
+    @Test
+    void deserialize_whenTamperedData_shouldThrowCookieDeserializeException() {
+        stubDeterministicHmac();
+
+        OAuth2AuthorizationRequest original = sampleAuthRequestWithRedirect("https://front/app/after");
+        String serialized = repo.serialize(original);
+
+        String[] parts = serialized.split("\\.");
+        assertThat(parts).hasSize(2);
+
+        String data = parts[0];
+        String sig = parts[1];
+
+        String tamperedData = flipLastChar(data);
+        String tampered = tamperedData + "." + sig;
+
+        assertThatThrownBy(() -> repo.deserialize(tampered, OAuth2AuthorizationRequest.class))
+                .isInstanceOf(CookieDeserializeException.class);
+    }
+
+    @Test
+    void serialize_whenHmacThrows_shouldThrowCookieSerializeException() {
+        when(timeTokenUtils.hmacSha256(anyString()))
+                .thenThrow(new RuntimeException("boom"));
+
+        OAuth2AuthorizationRequest original = sampleAuthRequestWithRedirect("https://front/app/after");
+
+        assertThatThrownBy(() -> repo.serialize(original))
+                .isInstanceOf(CookieSerializeException.class);
+    }
+
+    // ---- helpers ----
+
+    private static OAuth2AuthorizationRequest sampleAuthRequestWithRedirect(String redirectCookieValue) {
+        return OAuth2AuthorizationRequest.authorizationCode()
+                .authorizationUri("https://accounts.google.com/o/oauth2/v2/auth")
+                .clientId("client-123")
+                .redirectUri("https://api.nin.ua/login/oauth2/code/google")
+                .scopes(Set.of("openid", "email", "profile"))
+                .state("state-xyz")
+                .attributes(Map.of("k", "v"))
+                .additionalParameters(Map.of(
+                        REDIRECT_URI_COOKIE_NAME, redirectCookieValue,
+                        "access_type", "offline"
+                ))
+                .build();
+    }
+
+    private static String sha256Base64Url(String s) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] digest = md.digest(s.getBytes(StandardCharsets.UTF_8));
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static String flipLastChar(String s) {
+        if (s == null || s.isEmpty()) return "A";
+        char last = s.charAt(s.length() - 1);
+        char repl = (last == 'A') ? 'B' : 'A';
+        return s.substring(0, s.length() - 1) + repl;
+    }
+}

--- a/identity/src/test/java/ua/nin/identity/auth/service/HttpCookieServiceTest.java
+++ b/identity/src/test/java/ua/nin/identity/auth/service/HttpCookieServiceTest.java
@@ -10,7 +10,7 @@ class HttpCookieServiceTest {
 
     @Test
     void setRefreshCookie_writesHttpOnlyCookie() {
-        HttpCookieService service = new HttpCookieService();
+        HttpCookieService service = new HttpCookieService(14L, false);
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         service.setRefreshCookie(response, "token");
@@ -25,7 +25,7 @@ class HttpCookieServiceTest {
 
     @Test
     void clearRefreshCookie_setsExpiredCookie() {
-        HttpCookieService service = new HttpCookieService();
+        HttpCookieService service = new HttpCookieService(14L, false);
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         service.clearRefreshCookie(response);

--- a/identity/src/test/java/ua/nin/identity/auth/service/OAuth2SuccessHandlerTest.java
+++ b/identity/src/test/java/ua/nin/identity/auth/service/OAuth2SuccessHandlerTest.java
@@ -1,0 +1,148 @@
+package ua.nin.identity.auth.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import ua.nin.identity.auth.dto.IssueNewResult;
+import ua.nin.identity.auth.dto.OAuth2UserDto;
+import ua.nin.identity.auth.model.Role;
+import ua.nin.identity.auth.model.User;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OAuth2SuccessHandlerTest {
+
+    @Mock private Oauth2ProvisionService provisionService;
+    @Mock private AccessTokenService accessTokenService;
+    @Mock private RefreshTokenService refreshTokenService;
+    @Mock private HttpCookieService cookieService;
+
+    private ObjectMapper objectMapper;
+    private OAuth2SuccessHandler handler;
+
+    @Captor private ArgumentCaptor<OAuth2UserDto> oauthDtoCaptor;
+    @Captor private ArgumentCaptor<List<String>> rolesCaptor;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        handler = new OAuth2SuccessHandler(
+                provisionService,
+                accessTokenService,
+                refreshTokenService,
+                cookieService,
+                objectMapper
+        );
+        // @Value поле руками для unit-test
+        ReflectionTestUtils.setField(handler, "accessTtlMinutes", 10L);
+    }
+
+    @Test
+    void onAuthenticationSuccess_shouldProvisionIssueTokensSetCookie_andWriteJsonResponse() throws Exception {
+        // request/response
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(HttpHeaders.USER_AGENT, "JUnit-UA");
+        request.setRemoteAddr("203.0.113.10");
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // auth token + oidc user
+        OAuth2AuthenticationToken authentication = mock(OAuth2AuthenticationToken.class);
+        when(authentication.getAuthorizedClientRegistrationId()).thenReturn("google");
+
+        OidcUser oidcUser = mock(OidcUser.class);
+        when(authentication.getPrincipal()).thenReturn(oidcUser);
+
+        when(oidcUser.getSubject()).thenReturn("google-sub-123");
+        when(oidcUser.getEmail()).thenReturn("a@b.com");
+        when(oidcUser.getEmailVerified()).thenReturn(true);
+        when(oidcUser.getFullName()).thenReturn("Alice");
+        when(oidcUser.getPicture()).thenReturn("https://img.example/x.png");
+
+        // provision -> user
+        User user = new User();
+        user.setId(777L);
+        user.setRole(Role.USER);
+
+        when(provisionService.provision(any(OAuth2UserDto.class))).thenReturn(user);
+
+        // refresh issue
+        when(refreshTokenService.issueNew(eq(user), eq("JUnit-UA"), eq("203.0.113.10")))
+                .thenReturn(new IssueNewResult("raw.refresh.token", 55L));
+
+        // access issue
+        when(accessTokenService.createAccessToken(eq(777L), anyList()))
+                .thenReturn("access.jwt");
+
+        // act
+        handler.onAuthenticationSuccess(request, response, authentication);
+
+        // verify dto passed into provision (перевіряємо, що реально збирається з OIDC)
+        verify(provisionService).provision(oauthDtoCaptor.capture());
+        OAuth2UserDto dto = oauthDtoCaptor.getValue();
+
+        assertThat(dto.providerId()).isEqualTo("google-sub-123");
+        assertThat(dto.email()).isEqualTo("a@b.com");
+        assertThat(dto.emailVerified()).isTrue();
+        assertThat(dto.name()).isEqualTo("Alice");
+        assertThat(dto.picture()).isEqualTo("https://img.example/x.png");
+
+        // verify tokens + cookie
+        verify(refreshTokenService).issueNew(eq(user), eq("JUnit-UA"), eq("203.0.113.10"));
+        verify(accessTokenService).createAccessToken(eq(777L), rolesCaptor.capture());
+        assertThat(rolesCaptor.getValue()).containsExactly("USER");
+        verify(cookieService).setRefreshCookie(eq(response), eq("raw.refresh.token"));
+
+        // verify response
+        assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+        assertThat(response.getCharacterEncoding()).isEqualTo(StandardCharsets.UTF_8.name());
+        assertThat(response.getContentType()).startsWith(MediaType.APPLICATION_JSON_VALUE);
+
+        JsonNode json = objectMapper.readTree(response.getContentAsByteArray());
+
+        // поля залежать від AuthResponse. Тут перевірка за змістом:
+        assertThat(json.get("accessToken").asText()).isEqualTo("access.jwt");
+        assertThat(json.get("tokenType").asText()).isEqualTo("Bearer");
+        assertThat(json.get("expiresInSeconds").asLong()).isEqualTo(600L);
+        assertThat(json.get("userId").asLong()).isEqualTo(777L);
+        assertThat(json.get("role").asText()).isEqualTo("USER");
+    }
+
+    @Test
+    void onAuthenticationSuccess_whenPrincipalNotOidcUser_shouldThrowClassCastException() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        OAuth2User notOidc = mock(OAuth2User.class); // НЕ OidcUser
+
+        OAuth2AuthenticationToken authentication = mock(OAuth2AuthenticationToken.class);
+        when(authentication.getAuthorizedClientRegistrationId()).thenReturn("google");
+        when(authentication.getPrincipal()).thenReturn(notOidc);
+
+        assertThatThrownBy(() -> handler.onAuthenticationSuccess(request, response, authentication))
+                .isInstanceOf(ClassCastException.class);
+
+        // нічого не повинно бути випущено
+        verifyNoInteractions(provisionService, accessTokenService, refreshTokenService, cookieService);
+    }
+}

--- a/identity/src/test/java/ua/nin/identity/auth/service/Oauth2ProvisionServiceTest.java
+++ b/identity/src/test/java/ua/nin/identity/auth/service/Oauth2ProvisionServiceTest.java
@@ -1,0 +1,281 @@
+package ua.nin.identity.auth.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import ua.nin.identity.auth.dto.OAuth2UserDto;
+import ua.nin.identity.auth.exception.exceptions.NotFoundException;
+import ua.nin.identity.auth.model.OAuth2Identity;
+import ua.nin.identity.auth.model.Provider;
+import ua.nin.identity.auth.model.Role;
+import ua.nin.identity.auth.model.Status;
+import ua.nin.identity.auth.model.User;
+import ua.nin.identity.auth.repository.OAuth2IdentityRepository;
+import ua.nin.identity.auth.repository.UserRepository;
+import ua.nin.identity.profile.model.Profile;
+import ua.nin.identity.profile.repository.ProfileRepository;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class Oauth2ProvisionServiceTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private ProfileRepository profileRepository;
+    @Mock private OAuth2IdentityRepository identityRepository;
+
+    @InjectMocks private Oauth2ProvisionService service;
+
+    @Captor private ArgumentCaptor<User> userCaptor;
+    @Captor private ArgumentCaptor<OAuth2Identity> identityCaptor;
+    @Captor private ArgumentCaptor<Profile> profileCaptor;
+
+    private static OAuth2UserDto dtoGoogleVerified(String sub, String email, String name) {
+        return OAuth2UserDto.builder()
+                .provider(Provider.GOOGLE)
+                .providerId(sub)
+                .email(email)
+                .emailVerified(true)
+                .name(name)
+                .picture("pic")
+                .build();
+    }
+
+    private static OAuth2UserDto dtoGoogleUnverifiedNoEmail(String sub) {
+        return OAuth2UserDto.builder()
+                .provider(Provider.GOOGLE)
+                .providerId(sub)
+                .email(null)
+                .emailVerified(false)
+                .name("NoEmail User")
+                .picture(null)
+                .build();
+    }
+
+    @Test
+    void provision_whenIdentityExists_shouldTouchIdentity_andReturnUser() {
+        OAuth2UserDto dto = dtoGoogleVerified("sub-1", "a@b.com", "Alice");
+
+        OAuth2Identity identity = OAuth2Identity.builder()
+                .userId(10L)
+                .provider(Provider.GOOGLE)
+                .subject("sub-1")
+                .email("old@b.com")
+                .emailVerified(false)
+                .build();
+
+        when(identityRepository.findByProviderAndSubject(dto.provider(), dto.providerId()))
+                .thenReturn(Optional.of(identity));
+
+        User user = new User();
+        user.setId(10L);
+        user.setEmail("a@b.com");
+        user.setRole(Role.USER);
+        user.setStatus(Status.ACTIVE);
+
+        when(userRepository.findById(10L)).thenReturn(Optional.of(user));
+
+        User res = service.provision(dto);
+
+        assertThat(res).isSameAs(user);
+
+        // touchIdentity повинен оновити поля і зберегти identity
+        verify(identityRepository).save(identityCaptor.capture());
+        OAuth2Identity saved = identityCaptor.getValue();
+        assertThat(saved.getEmail()).isEqualTo("a@b.com");
+        assertThat(saved.isEmailVerified()).isTrue();
+        assertThat(saved.getUpdatedAt()).isNotNull();
+
+        verify(userRepository, never()).save(any(User.class));
+        verify(profileRepository, never()).saveAndFlush(any(Profile.class));
+    }
+
+    @Test
+    void provision_whenIdentityExistsButUserMissing_shouldThrowNotFound() {
+        OAuth2UserDto dto = dtoGoogleVerified("sub-1", "a@b.com", "Alice");
+
+        OAuth2Identity identity = OAuth2Identity.builder()
+                .userId(10L)
+                .provider(Provider.GOOGLE)
+                .subject("sub-1")
+                .build();
+
+        when(identityRepository.findByProviderAndSubject(dto.provider(), dto.providerId()))
+                .thenReturn(Optional.of(identity));
+
+        when(userRepository.findById(10L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.provision(dto))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("User not found: 10");
+
+        verify(identityRepository, never()).save(any(OAuth2Identity.class));
+    }
+
+    @Test
+    void provision_whenUserFoundByVerifiedEmail_andPendingEmail_shouldActivate_createProfile_linkIdentity() {
+        OAuth2UserDto dto = dtoGoogleVerified("sub-2", "pending@b.com", "Pending");
+
+        when(identityRepository.findByProviderAndSubject(dto.provider(), dto.providerId()))
+                .thenReturn(Optional.empty());
+
+        User existing = new User();
+        existing.setId(5L);
+        existing.setEmail("pending@b.com");
+        existing.setRole(Role.USER);
+        existing.setStatus(Status.PENDING_EMAIL);
+
+        when(userRepository.findByEmail("pending@b.com")).thenReturn(Optional.of(existing));
+
+        when(profileRepository.findByUserId(5L)).thenReturn(Optional.empty());
+        // deriveUsername -> "pending"
+        when(profileRepository.existsByUsername("pending")).thenReturn(false);
+
+        User res = service.provision(dto);
+
+        assertThat(res.getId()).isEqualTo(5L);
+        assertThat(res.getStatus()).isEqualTo(Status.ACTIVE);
+
+        // user повинен бути збережений (через зміну статуса)
+        verify(userRepository, atLeastOnce()).save(userCaptor.capture());
+        assertThat(userCaptor.getValue().getStatus()).isEqualTo(Status.ACTIVE);
+
+        // profile створюється
+        verify(profileRepository).saveAndFlush(profileCaptor.capture());
+        Profile p = profileCaptor.getValue();
+        assertThat(p.getUser().getId()).isEqualTo(5L);
+        assertThat(p.getUsername()).isEqualTo("pending");
+        assertThat(p.getDisplayName()).isEqualTo("Pending");
+
+        // identity створюється
+        verify(identityRepository).save(identityCaptor.capture());
+        OAuth2Identity identity = identityCaptor.getValue();
+        assertThat(identity.getUserId()).isEqualTo(5L);
+        assertThat(identity.getProvider()).isEqualTo(Provider.GOOGLE);
+        assertThat(identity.getSubject()).isEqualTo("sub-2");
+        assertThat(identity.getEmail()).isEqualTo("pending@b.com");
+        assertThat(identity.isEmailVerified()).isTrue();
+    }
+
+    @Test
+    void provision_whenNoUser_shouldCreateUser_withFallbackEmail_pendingAndCreateProfile_andLinkIdentity() {
+        OAuth2UserDto dto = dtoGoogleUnverifiedNoEmail("sub-3");
+
+        when(identityRepository.findByProviderAndSubject(dto.provider(), dto.providerId()))
+                .thenReturn(Optional.empty());
+
+        // email is null -> findByEmail не повинен вызиваться взагалі (або може, але в тебе умова захищає)
+        // userRepository.save повинен присвоїти id
+        when(userRepository.save(any(User.class))).thenAnswer(inv -> {
+            User u = inv.getArgument(0);
+            if (u.getId() == null) u.setId(100L);
+            return u;
+        });
+
+        when(profileRepository.findByUserId(100L)).thenReturn(Optional.empty());
+        // deriveUsername: при email null він бере name => "NoEmail_User"
+        when(profileRepository.existsByUsername("NoEmail_User")).thenReturn(false);
+
+        User res = service.provision(dto);
+
+        assertThat(res.getId()).isEqualTo(100L);
+        assertThat(res.getRole()).isEqualTo(Role.USER);
+        assertThat(res.getStatus()).isEqualTo(Status.PENDING_EMAIL);
+        assertThat(res.getEmail()).isEqualTo("no-email@google.local");
+
+        verify(profileRepository).saveAndFlush(profileCaptor.capture());
+        assertThat(profileCaptor.getValue().getUsername()).isEqualTo("NoEmail_User");
+
+        verify(identityRepository).save(identityCaptor.capture());
+        assertThat(identityCaptor.getValue().getUserId()).isEqualTo(100L);
+        assertThat(identityCaptor.getValue().getEmail()).isNull();
+        assertThat(identityCaptor.getValue().isEmailVerified()).isFalse();
+    }
+
+    @Test
+    void provision_uniqueUsername_whenBaseTaken_shouldAppendUuid_andKeepLengthLimit() {
+        OAuth2UserDto dto = dtoGoogleVerified("sub-4", "john@b.com", "John");
+
+        when(identityRepository.findByProviderAndSubject(dto.provider(), dto.providerId()))
+                .thenReturn(Optional.empty());
+
+        User existing = new User();
+        existing.setId(7L);
+        existing.setEmail("john@b.com");
+        existing.setRole(Role.USER);
+        existing.setStatus(Status.ACTIVE);
+        when(userRepository.findByEmail("john@b.com")).thenReturn(Optional.of(existing));
+
+        when(profileRepository.findByUserId(7L)).thenReturn(Optional.empty());
+
+        // base = "john"
+        when(profileRepository.existsByUsername("john")).thenReturn(true);
+        // для будь-якого іншого username (uuid варіант) -> false
+        when(profileRepository.existsByUsername(argThat(s -> s != null && !s.equals("john"))))
+                .thenReturn(false);
+
+        service.provision(dto);
+
+        verify(profileRepository).saveAndFlush(profileCaptor.capture());
+        String username = profileCaptor.getValue().getUsername();
+
+        assertThat(username).startsWith("john_");
+        assertThat(username.length()).isLessThanOrEqualTo(64);
+    }
+
+    @Test
+    void provision_uniqueUsername_whenBaseAndCandidateTaken_shouldThrow() {
+        OAuth2UserDto dto = dtoGoogleVerified("sub-5", "kate@b.com", "Kate");
+
+        when(identityRepository.findByProviderAndSubject(dto.provider(), dto.providerId()))
+                .thenReturn(Optional.empty());
+
+        User existing = new User();
+        existing.setId(9L);
+        existing.setEmail("kate@b.com");
+        existing.setRole(Role.USER);
+        existing.setStatus(Status.ACTIVE);
+        when(userRepository.findByEmail("kate@b.com")).thenReturn(Optional.of(existing));
+
+        when(profileRepository.findByUserId(9L)).thenReturn(Optional.empty());
+
+        // base і candidate "зайняті"
+        when(profileRepository.existsByUsername(anyString())).thenReturn(true);
+
+        assertThatThrownBy(() -> service.provision(dto))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Failed to allocate unique username");
+
+        verify(profileRepository, never()).saveAndFlush(any(Profile.class));
+    }
+
+    @Test
+    void provision_whenProfileAlreadyExists_shouldNotCreateProfile() {
+        OAuth2UserDto dto = dtoGoogleVerified("sub-6", "hasprofile@b.com", "HP");
+
+        when(identityRepository.findByProviderAndSubject(dto.provider(), dto.providerId()))
+                .thenReturn(Optional.empty());
+
+        User existing = new User();
+        existing.setId(11L);
+        existing.setEmail("hasprofile@b.com");
+        existing.setRole(Role.USER);
+        existing.setStatus(Status.ACTIVE);
+        when(userRepository.findByEmail("hasprofile@b.com")).thenReturn(Optional.of(existing));
+
+        when(profileRepository.findByUserId(11L)).thenReturn(Optional.of(new Profile()));
+
+        service.provision(dto);
+
+        verify(profileRepository, never()).existsByUsername(anyString());
+        verify(profileRepository, never()).saveAndFlush(any(Profile.class));
+
+        // identity все рівно створюється
+        verify(identityRepository).save(any(OAuth2Identity.class));
+    }
+}

--- a/identity/src/test/java/ua/nin/identity/auth/util/TimeTokenUtilsTest.java
+++ b/identity/src/test/java/ua/nin/identity/auth/util/TimeTokenUtilsTest.java
@@ -1,7 +1,6 @@
 package ua.nin.identity.auth.util;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.security.SecureRandom;
 
@@ -11,9 +10,7 @@ class TimeTokenUtilsTest {
 
     @Test
     void generateRawToken_uniqueAndNonEmpty() {
-        TimeTokenUtils utils = new TimeTokenUtils(new SecureRandom());
-        ReflectionTestUtils.setField(utils, "bytes", 32);
-        ReflectionTestUtils.setField(utils, "pepper", "pepper");
+        TimeTokenUtils utils = new TimeTokenUtils(new SecureRandom(), 32, "pepper", "secret");
 
         String token1 = utils.generateRawToken();
         String token2 = utils.generateRawToken();
@@ -25,8 +22,7 @@ class TimeTokenUtilsTest {
 
     @Test
     void hash_isDeterministicAndNotRaw() {
-        TimeTokenUtils utils = new TimeTokenUtils(new SecureRandom());
-        ReflectionTestUtils.setField(utils, "pepper", "pepper");
+        TimeTokenUtils utils = new TimeTokenUtils(new SecureRandom(), 32, "pepper", "secret");
 
         String hash1 = utils.hash("raw");
         String hash2 = utils.hash("raw");


### PR DESCRIPTION
Added OAuth2 authentication with cookie-based authorization request state storage.

## Development links
Closes #74
Closes #75
Closes #76
Closes #162
Closes #163
Closes #164
Closes #166
Closes #167
Closes #168
Closes #171
Closes #172
Closes #173
Closes #174