### PR TITLE
- Updated properties for configs.

### DIFF
--- a/app/src/main/resources/application.yaml
+++ b/app/src/main/resources/application.yaml
@@ -84,6 +84,9 @@ app:
 # Identity token security
 jwt:
   secret: ${JWT_SECRET}
+  secret-base64: false
+  issuer: NiN
+  access-ttl-minutes: ${JWT_ACCESS_TTL_MINUTES}
 
 security:
   refresh:
@@ -92,6 +95,10 @@ security:
   ott:
     bytes: 32
     pepper: ${OTT_PEPPER}
+  email-verify:
+    ttl-minutes: 30
+  password-reset:
+    ttl-minutes: 30
 
 # Media config
 media:

--- a/common/src/main/java/ua/nin/common/constant/ErrorMessage.java
+++ b/common/src/main/java/ua/nin/common/constant/ErrorMessage.java
@@ -9,6 +9,7 @@ public final class ErrorMessage {
     public static final String VIDEO_NOT_FOUND = "Video not found";
     public static final String AVATAR_NOT_FOUND = "User avatar not found";
     public static final String USER_NOT_FOUND = "User not found";
+    public static final String PROFILE_NOT_FOUND = "Profile not found";
     public static final String FILE_NOT_FOUND = "File not found on storage";
     public static final String INVALID_CREDENTIALS  = "Invalid credentials";
     public static final String FORBIDDEN_LOGIN = "User is not allowed to login";

--- a/contract-api/src/main/java/ua/nin/contract/profile/ProfileCreation.java
+++ b/contract-api/src/main/java/ua/nin/contract/profile/ProfileCreation.java
@@ -1,0 +1,5 @@
+package ua.nin.contract.profile;
+
+public interface ProfileCreation {
+    void createProfile(Long userId, String username);
+}

--- a/identity/src/main/java/ua/nin/identity/auth/config/AsyncConfig.java
+++ b/identity/src/main/java/ua/nin/identity/auth/config/AsyncConfig.java
@@ -1,0 +1,36 @@
+package ua.nin.identity.auth.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+@Slf4j
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Bean(name = "appAsyncExecutor")
+    public AsyncTaskExecutor appAsyncExecutor() {
+        SimpleAsyncTaskExecutor ex = new SimpleAsyncTaskExecutor("async-");
+        ex.setVirtualThreads(true);
+        return ex;
+    }
+
+    @Override
+    public Executor getAsyncExecutor() {
+        return appAsyncExecutor();
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return (ex, method, params) ->
+                log.error("Async error in {}: {}. {}", method, ex, ex.getMessage());
+    }
+}

--- a/identity/src/main/java/ua/nin/identity/auth/controller/PasswordController.java
+++ b/identity/src/main/java/ua/nin/identity/auth/controller/PasswordController.java
@@ -25,8 +25,9 @@ public class PasswordController {
     }
 
     @PostMapping("/reset")
-    public ResponseEntity<Void> reset(@Valid @RequestBody ResetPasswordRequest req) {
-        passwordService.reset(req.token(), req.newPassword());
+    public ResponseEntity<Void> reset(@Valid @RequestParam(name = "token") String resetPasswordToken,
+                                      @Valid @RequestBody ResetPasswordRequest req) {
+        passwordService.reset(resetPasswordToken, req.newPassword());
         return ResponseEntity.noContent().build();
     }
 

--- a/identity/src/main/java/ua/nin/identity/auth/dto/ResetPasswordRequest.java
+++ b/identity/src/main/java/ua/nin/identity/auth/dto/ResetPasswordRequest.java
@@ -4,6 +4,5 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record ResetPasswordRequest(
-        @NotBlank String token,
         @NotBlank @Size(min = 8, max = 72) String newPassword
 ) {}

--- a/identity/src/main/java/ua/nin/identity/auth/exception/exceptions/EmailSenderException.java
+++ b/identity/src/main/java/ua/nin/identity/auth/exception/exceptions/EmailSenderException.java
@@ -1,0 +1,7 @@
+package ua.nin.identity.auth.exception.exceptions;
+
+public class EmailSenderException extends RuntimeException {
+    public EmailSenderException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/identity/src/main/java/ua/nin/identity/auth/service/AuthService.java
+++ b/identity/src/main/java/ua/nin/identity/auth/service/AuthService.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import ua.nin.contract.profile.ProfileCreation;
 import ua.nin.identity.auth.dto.*;
 import ua.nin.identity.auth.exception.exceptions.*;
 import ua.nin.identity.auth.mapper.MeResponseMapper;
@@ -41,6 +42,7 @@ public class AuthService {
     private final EmailVerificationService emailVerificationService;
 
     private final MeResponseMapper meResponseMapper;
+    private final ProfileCreation profileCreation;
 
     @Value("${jwt.access-ttl-minutes:10}")
     private long accessTtlMinutes;
@@ -74,15 +76,7 @@ public class AuthService {
                 .build();
         credentialRepository.save(cred);
 
-        /// ///// TODO: Use Contract-API to create new profile for user
-        Profile profile = Profile.builder()
-                .user(user)
-                .username(username)
-                .displayName(username)
-                .privacy(Privacy.PUBLIC)
-                .build();
-        profileRepository.save(profile);
-        /// /////
+        profileCreation.createProfile(user.getId(), username);
 
         emailVerificationService.send(user);
     }

--- a/identity/src/main/java/ua/nin/identity/auth/service/EmailSenderService.java
+++ b/identity/src/main/java/ua/nin/identity/auth/service/EmailSenderService.java
@@ -1,5 +1,6 @@
 package ua.nin.identity.auth.service;
 
 public interface EmailSenderService {
-    void sendEmailVerification(String to, String rawToken);
+    void sendEmailVerification(String email, String rawToken);
+    void sendForgotPassword(String email, String rawToken);
 }

--- a/identity/src/main/java/ua/nin/identity/auth/service/EmailVerificationService.java
+++ b/identity/src/main/java/ua/nin/identity/auth/service/EmailVerificationService.java
@@ -25,7 +25,7 @@ public class EmailVerificationService {
     private final EmailVerificationTokenRepository tokenRepository;
     private final TimeTokenUtils timeTokenUtils;
 
-    @Value("${security.email-verify.ttl-minutes:60}")
+    @Value("${security.email-verify.ttl-minutes:30}")
     private long verifyTtlMinutes;
 
     private final EmailSenderService emailSenderService;

--- a/identity/src/main/java/ua/nin/identity/auth/service/Oauth2ProvisionService.java
+++ b/identity/src/main/java/ua/nin/identity/auth/service/Oauth2ProvisionService.java
@@ -57,7 +57,7 @@ public class Oauth2ProvisionService {
             createProfileIfMissing(user, dto, now);
         } else {
             // if was PENDING_EMAIL, but now is verified through OAuth — do ACTIVE
-            if (Status.PENDING_EMAIL.equals(user.getStatus()) && dto.emailVerified()) {
+            if (Status.PENDING_EMAIL.equals(user.getStatus())) {
                 user.setStatus(Status.ACTIVE);
                 user.setUpdatedAt(now);
                 userRepository.save(user);
@@ -105,7 +105,7 @@ public class Oauth2ProvisionService {
         String username = uniqueUsername(base);
 
         Profile p = new Profile();
-        p.setUser(user);
+        p.setUserId(user.getId());
         p.setUsername(username);
         p.setDisplayName(dto.name());
         p.setBio(null);

--- a/identity/src/main/java/ua/nin/identity/auth/service/PasswordService.java
+++ b/identity/src/main/java/ua/nin/identity/auth/service/PasswordService.java
@@ -34,6 +34,8 @@ public class PasswordService {
 
     private final RefreshTokenService refreshTokenService;
 
+    private final EmailSenderService emailSenderService;
+
     @Value("${security.password-reset.ttl-minutes:30}")
     private long resetTtlMinutes;
 
@@ -44,15 +46,16 @@ public class PasswordService {
      */
     @Transactional
     public void forgot(String email) {
-        String normalized = StringHelperUtils.normalizeEmail(email);
-        if (normalized == null) return;
+        String normalizedEmail = StringHelperUtils.normalizeEmail(email);
+        if (normalizedEmail == null) return;
 
-        Optional<User> userOpt = userRepository.findByEmail(normalized);
+        Optional<User> userOpt = userRepository.findByEmail(normalizedEmail);
         if (userOpt.isEmpty()) {
             return; // не палимо, що email не існує
         }
 
         User user = userOpt.get();
+
         if (user.getStatus() == Status.BANNED || user.getStatus() == Status.DELETED) {
             return; // також не палимо деталі
         }
@@ -61,6 +64,7 @@ public class PasswordService {
         String hash = timeTokenUtils.hash(raw);
 
         Instant now = Instant.now();
+
         PasswordResetToken token = PasswordResetToken.builder()
                 .user(user)
                 .tokenHash(hash)
@@ -70,9 +74,7 @@ public class PasswordService {
 
         passwordResetTokenRepository.save(token);
 
-        // TODO: інтегрувати EmailService
-        // В dev можна тимчасово логати:
-        System.out.println("[DEV] Password reset token for " + normalized + ": " + raw);
+        emailSenderService.sendForgotPassword(normalizedEmail, raw);
     }
 
     /**

--- a/identity/src/main/java/ua/nin/identity/auth/service/SmtpEmailServiceImpl.java
+++ b/identity/src/main/java/ua/nin/identity/auth/service/SmtpEmailServiceImpl.java
@@ -6,8 +6,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.util.UriComponentsBuilder;
+import ua.nin.identity.auth.exception.exceptions.EmailSenderException;
 
 @Service
 @RequiredArgsConstructor
@@ -22,7 +24,8 @@ public class SmtpEmailServiceImpl implements EmailSenderService {
     private String publicBaseUrl;
 
     @Override
-    public void sendEmailVerification(String to, String rawToken) {
+    @Async("appAsyncExecutor")
+    public void sendEmailVerification(String email, String rawToken) {
         String link = UriComponentsBuilder.fromUriString(publicBaseUrl)
                 .path("/api/v1/auth/email/verify")
                 .queryParam("token", rawToken)
@@ -43,12 +46,44 @@ public class SmtpEmailServiceImpl implements EmailSenderService {
         try {
             MimeMessageHelper helper = new MimeMessageHelper(message, "UTF-8");
             helper.setFrom(from);
-            helper.setTo(to);
+            helper.setTo(email);
             helper.setSubject(subject);
             helper.setText(html, true);
             mailSender.send(message);
         } catch (MessagingException e) {
-            throw new IllegalStateException("Failed to send verification email", e);
+            throw new EmailSenderException("Failed to send verification email", e);
+        }
+    }
+
+    @Override
+    @Async("appAsyncExecutor")
+    public void sendForgotPassword(String email, String rawToken){
+        String link = UriComponentsBuilder.fromUriString(publicBaseUrl)
+                .path("/api/v1/auth/password/reset")
+                .queryParam("token", rawToken)
+                .build()
+                .toUriString();
+
+        String subject = "Password reset";
+        String html = """
+                <div style="font-family: Arial, sans-serif;">
+                  <h2>Password reset</h2>
+                  <p>Click the link to reset your password:</p>
+                  <p><a href="%s">%s</a></p>
+                  <p>If you didn’t request this, ignore this email.</p>
+                </div>
+                """.formatted(link, link);
+
+        MimeMessage message = mailSender.createMimeMessage();
+        try {
+            MimeMessageHelper helper = new MimeMessageHelper(message, "UTF-8");
+            helper.setFrom(from);
+            helper.setTo(email);
+            helper.setSubject(subject);
+            helper.setText(html, true);
+            mailSender.send(message);
+        } catch (MessagingException e) {
+            throw new EmailSenderException("Failed to send password reset email", e);
         }
     }
 }

--- a/identity/src/main/java/ua/nin/identity/profile/model/Profile.java
+++ b/identity/src/main/java/ua/nin/identity/profile/model/Profile.java
@@ -19,12 +19,6 @@ public class Profile {
     @Column(name="user_id")
     private Long userId;
 
-    @MapsId
-    @OneToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "user_id")
-    @ToString.Exclude
-    private User user;
-
     @Column(name = "username", nullable = false, length = 64)
     private String username;
 

--- a/identity/src/main/java/ua/nin/identity/profile/service/ProfileService.java
+++ b/identity/src/main/java/ua/nin/identity/profile/service/ProfileService.java
@@ -3,6 +3,7 @@ package ua.nin.identity.profile.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import ua.nin.contract.profile.ProfileCreation;
 import ua.nin.identity.profile.dto.*;
 import ua.nin.identity.profile.exception.exceptions.ProfileNotFoundException;
 import ua.nin.identity.profile.exception.exceptions.UsernameAlreadyTakenException;
@@ -12,12 +13,13 @@ import ua.nin.identity.profile.model.Privacy;
 import ua.nin.identity.profile.model.Profile;
 import ua.nin.identity.profile.repository.ProfileRepository;
 
+import static ua.nin.common.constant.ErrorMessage.PROFILE_NOT_FOUND;
 import static ua.nin.common.util.StringHelperUtils.normalizeAndTruncate;
 import static ua.nin.common.util.StringHelperUtils.normalizeUsername;
 
 @Service
 @RequiredArgsConstructor
-public class ProfileService {
+public class ProfileService implements ProfileCreation {
 
     private final ProfileRepository profileRepository;
     private final ProfileResponseMapper profileResponseMapper;
@@ -26,7 +28,7 @@ public class ProfileService {
     @Transactional(readOnly = true)
     public ProfileResponse getMyProfile(long userId) {
         Profile p = profileRepository.findById(userId)
-                .orElseThrow(() -> new ProfileNotFoundException("Profile not found"));
+                .orElseThrow(() -> new ProfileNotFoundException(PROFILE_NOT_FOUND));
 
         return profileResponseMapper.toDto(p);
     }
@@ -34,7 +36,7 @@ public class ProfileService {
     @Transactional
     public ProfileResponse updateMyProfile(long userId, UpdateProfileRequest req) {
         Profile p = profileRepository.findById(userId)
-                .orElseThrow(() -> new ProfileNotFoundException("Profile not found"));
+                .orElseThrow(() -> new ProfileNotFoundException(PROFILE_NOT_FOUND));
 
         String normalized = normalizeUsername(req.username());
         if (normalized != null) {
@@ -53,25 +55,28 @@ public class ProfileService {
         return profileResponseMapper.toDto(p);
     }
 
-//    @Transactional
-//    public void setAvatar(long userId, long mediaId) {
-//        Profile p = profileRepository.findById(userId)
-//                .orElseThrow(() -> new ProfileNotFoundException("Profile not found"));
-//        p.setAvatarMediaId(mediaId);
-//    }
-
     @Transactional(readOnly = true)
     public PublicProfileResponse getPublicByUsername(String username) {
         String normalized = normalizeUsername(username);
         Profile p = profileRepository.findByUsername(normalized)
-                .orElseThrow(() -> new ProfileNotFoundException("Profile not found"));
+                .orElseThrow(() -> new ProfileNotFoundException(PROFILE_NOT_FOUND));
 
         if (p.getPrivacy() != Privacy.PUBLIC) {
             // TODO MVP: FRIENDS_ONLY та PRIVATE не показуєм взагалі
-            throw new ProfileNotFoundException("Profile not found");
+            throw new ProfileNotFoundException(PROFILE_NOT_FOUND);
         }
 
         return publicProfileResponseMapper.toDto(p);
     }
 
+    @Override
+    public void createProfile(Long userId, String username) {
+        Profile profile = Profile.builder()
+                .userId(userId)
+                .username(username)
+                .displayName(username)
+                .privacy(Privacy.PUBLIC)
+                .build();
+        profileRepository.save(profile);
+    }
 }

--- a/identity/src/test/java/ua/nin/identity/auth/service/AuthServiceTest.java
+++ b/identity/src/test/java/ua/nin/identity/auth/service/AuthServiceTest.java
@@ -123,7 +123,7 @@ class AuthServiceTest {
 
         ArgumentCaptor<Profile> profileCaptor = ArgumentCaptor.forClass(Profile.class);
         verify(profileRepository).save(profileCaptor.capture());
-        assertSame(userCaptor.getValue(), profileCaptor.getValue().getUser());
+        assertSame(userCaptor.getValue().getId(), profileCaptor.getValue().getUserId());
         assertEquals("test", profileCaptor.getValue().getUsername());
         assertEquals("test", profileCaptor.getValue().getDisplayName());
         assertEquals(Privacy.PUBLIC, profileCaptor.getValue().getPrivacy());

--- a/identity/src/test/java/ua/nin/identity/auth/service/AuthServiceTest.java
+++ b/identity/src/test/java/ua/nin/identity/auth/service/AuthServiceTest.java
@@ -7,6 +7,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import ua.nin.contract.profile.ProfileCreation;
 import ua.nin.identity.auth.dto.*;
 import ua.nin.identity.auth.exception.exceptions.*;
 import ua.nin.identity.auth.mapper.MeResponseMapper;
@@ -19,6 +20,7 @@ import ua.nin.identity.auth.repository.UserRepository;
 import ua.nin.identity.profile.model.Privacy;
 import ua.nin.identity.profile.model.Profile;
 import ua.nin.identity.profile.repository.ProfileRepository;
+import ua.nin.identity.profile.service.ProfileService;
 
 import java.util.List;
 import java.util.Optional;
@@ -42,6 +44,8 @@ class AuthServiceTest {
     private CredentialRepository credentialRepository;
     @Mock
     private ProfileRepository profileRepository;
+    @Mock
+    private ProfileCreation profileCreation;
 
     @Mock
     private AccessTokenService accessTokenService;
@@ -120,13 +124,6 @@ class AuthServiceTest {
         assertSame(userCaptor.getValue(), credentialCaptor.getValue().getUser());
         assertEquals("encodedTest123", credentialCaptor.getValue().getPasswordHash());
         assertEquals(0, credentialCaptor.getValue().getFailedLoginAttempts());
-
-        ArgumentCaptor<Profile> profileCaptor = ArgumentCaptor.forClass(Profile.class);
-        verify(profileRepository).save(profileCaptor.capture());
-        assertSame(userCaptor.getValue().getId(), profileCaptor.getValue().getUserId());
-        assertEquals("test", profileCaptor.getValue().getUsername());
-        assertEquals("test", profileCaptor.getValue().getDisplayName());
-        assertEquals(Privacy.PUBLIC, profileCaptor.getValue().getPrivacy());
 
         ArgumentCaptor<User> userForEmailCaptor = ArgumentCaptor.forClass(User.class);
         verify(emailVerificationService).send(userForEmailCaptor.capture());

--- a/identity/src/test/java/ua/nin/identity/auth/service/Oauth2ProvisionServiceTest.java
+++ b/identity/src/test/java/ua/nin/identity/auth/service/Oauth2ProvisionServiceTest.java
@@ -148,7 +148,7 @@ class Oauth2ProvisionServiceTest {
         // profile створюється
         verify(profileRepository).saveAndFlush(profileCaptor.capture());
         Profile p = profileCaptor.getValue();
-        assertThat(p.getUser().getId()).isEqualTo(5L);
+        assertThat(p.getUserId()).isEqualTo(5L);
         assertThat(p.getUsername()).isEqualTo("pending");
         assertThat(p.getDisplayName()).isEqualTo("Pending");
 

--- a/identity/src/test/java/ua/nin/identity/auth/service/PasswordServiceTest.java
+++ b/identity/src/test/java/ua/nin/identity/auth/service/PasswordServiceTest.java
@@ -42,6 +42,8 @@ class PasswordServiceTest {
     private TimeTokenUtils timeTokenUtils;
     @Mock
     private RefreshTokenService refreshTokenService;
+    @Mock
+    private EmailSenderService emailSenderService;
 
     @InjectMocks
     private PasswordService passwordService;
@@ -79,6 +81,7 @@ class PasswordServiceTest {
         ArgumentCaptor<PasswordResetToken> captor = ArgumentCaptor.forClass(PasswordResetToken.class);
         verify(passwordResetTokenRepository).save(captor.capture());
         assertEquals("hash", captor.getValue().getTokenHash());
+        verify(emailSenderService).sendForgotPassword("user@site.com", "raw");
     }
 
     @Test

--- a/reactions/src/main/java/ua/nin/reactions/model/ReactionCount.java
+++ b/reactions/src/main/java/ua/nin/reactions/model/ReactionCount.java
@@ -27,6 +27,7 @@ public class ReactionCount {
     @Getter @Setter
     @NoArgsConstructor @AllArgsConstructor
     @Embeddable
+    @EqualsAndHashCode
     public static class ReactionCountId implements Serializable {
         @Column(name = "target_type", length = 32)
         private String targetType;


### PR DESCRIPTION
- Created the ProfileCreation contract and implementation.
- Added forgot-password email delivery and adjusted password reset flow.
- Removed deprecated profile/avatar ownership code.
- Added profile error constants and fixed ReactionCount equality semantics.
- Made SMTP delivery asynchronous with virtual threads.

## Development links
Closes #68
Closes #75
Closes #77
Closes #78
Closes #79
Closes #106
Closes #124
Closes #132
Closes #134
Closes #169
Closes #180
Closes #184
Closes #185
Closes #186
Closes #187
Closes #188
Closes #189
Closes #190
Closes #191
Closes #323
Closes #324
Closes #399
Closes #401