### PR TITLE
- Updated CI/CD, so docker push is happening only when github event is 'push'.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,7 +141,7 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          push: true
+          push: ${{ github.event_name == 'push' }}
           tags: ${{ env.dockerRepoName }}:test-${{ needs.build.outputs.GITHUB_SHA_SHORT }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Updated CI/CD so Docker publishing occurs only for push events.

## Development links
Closes #112
Closes #113
Closes #350
Closes #354