### PR TITLE
- Fixed FK in refresh_tokens. (family_id,user_id) -> (id, user_id) to (family_id) -> (id). - Fixed RefreshToken model, repo and service, according to FK changes.

### DIFF
--- a/identity/src/main/java/ua/nin/identity/auth/model/RefreshToken.java
+++ b/identity/src/main/java/ua/nin/identity/auth/model/RefreshToken.java
@@ -29,7 +29,6 @@ public class RefreshToken {
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "family_id", referencedColumnName = "id", nullable = false)
-    @JoinColumn(name = "user_id", referencedColumnName = "user_id", nullable = false, insertable = false, updatable = false)
     @ToString.Exclude
     private RefreshTokenFamily family;
 

--- a/identity/src/main/java/ua/nin/identity/auth/repository/RefreshTokenRepository.java
+++ b/identity/src/main/java/ua/nin/identity/auth/repository/RefreshTokenRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import ua.nin.identity.auth.model.RefreshToken;
+import ua.nin.identity.auth.model.RefreshTokenFamily;
 
 import java.time.Instant;
 import java.util.Optional;
@@ -17,10 +18,10 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     @Query("""
         UPDATE RefreshToken t
            SET t.revokedAt = :now
-         WHERE t.familyId = :familyId
+         WHERE t.family = :family
            AND t.revokedAt is null
         """)
-    void revokeAllInFamily(long familyId, Instant now);
+    void revokeAllInFamily(RefreshTokenFamily family, Instant now);
 
     @Modifying
     @Query("""

--- a/identity/src/main/java/ua/nin/identity/auth/service/RefreshTokenService.java
+++ b/identity/src/main/java/ua/nin/identity/auth/service/RefreshTokenService.java
@@ -100,14 +100,14 @@ public class RefreshTokenService {
         // 2) expiry
         if (current.isExpired(now)) {
             // можна ревокнути токен або навіть family
-            revokeFamilyInternal(family.getId(), now);
+            revokeFamilyInternal(family, now);
             throw new InvalidRefreshTokenException("Refresh token expired");
         }
 
         // 3) reuse detection: якщо токен вже був використаний для rotation або logout
         if (current.isRevoked() || current.getReplacedBy() != null) {
             // компрометація: відрубаємо всю family, щоб атакер не міг продовжити
-            revokeFamilyInternal(family.getId(), now);
+            revokeFamilyInternal(family, now);
             throw new RefreshReuseDetectedException("Refresh reuse detected - family revoked");
         }
 
@@ -150,7 +150,7 @@ public class RefreshTokenService {
         String hash = timeTokenUtils.hash(rawRefreshToken);
 
         refreshTokenRepository.findByTokenHash(hash)
-                .ifPresent(token -> revokeFamilyInternal(token.getFamily().getId(), now));
+                .ifPresent(token -> revokeFamilyInternal(token.getFamily(), now));
     }
 
     /**
@@ -171,11 +171,11 @@ public class RefreshTokenService {
         Instant now = Instant.now();
         RefreshTokenFamily family = familyRepository.findByIdAndUser_Id(familyId, userId)
                 .orElseThrow(() -> new InvalidRefreshTokenException("Family not found"));
-        revokeFamilyInternal(family.getId(), now);
+        revokeFamilyInternal(family, now);
     }
 
-    private void revokeFamilyInternal(long familyId, Instant now) {
-        familyRepository.revokeFamily(familyId, now);
-        refreshTokenRepository.revokeAllInFamily(familyId, now);
+    private void revokeFamilyInternal(RefreshTokenFamily family, Instant now) {
+        familyRepository.revokeFamily(family.getId(), now);
+        refreshTokenRepository.revokeAllInFamily(family, now);
     }
 }

--- a/identity/src/main/resources/db/changelog/logs/050_refresh_tokens.xml
+++ b/identity/src/main/resources/db/changelog/logs/050_refresh_tokens.xml
@@ -56,10 +56,10 @@
         <addForeignKeyConstraint
                 baseTableSchemaName="authentication"
                 baseTableName="refresh_tokens"
-                baseColumnNames="family_id,user_id"
+                baseColumnNames="family_id"
                 referencedTableSchemaName="authentication"
                 referencedTableName="refresh_token_families"
-                referencedColumnNames="id,user_id"
+                referencedColumnNames="id"
                 constraintName="fk_refresh_tokens_family_user"
                 onDelete="CASCADE"/>
 

--- a/identity/src/test/java/ua/nin/identity/auth/service/RefreshTokenServiceTest.java
+++ b/identity/src/test/java/ua/nin/identity/auth/service/RefreshTokenServiceTest.java
@@ -116,7 +116,7 @@ class RefreshTokenServiceTest {
                 .hasMessageContaining("expired");
 
         verify(familyRepository).revokeFamily(eq(10L), any(Instant.class));
-        verify(refreshTokenRepository).revokeAllInFamily(eq(10L), any(Instant.class));
+        verify(refreshTokenRepository).revokeAllInFamily(eq(family), any(Instant.class));
     }
 
     @Test
@@ -140,7 +140,7 @@ class RefreshTokenServiceTest {
                 .hasMessageContaining("reuse detected");
 
         verify(familyRepository).revokeFamily(eq(10L), any(Instant.class));
-        verify(refreshTokenRepository).revokeAllInFamily(eq(10L), any(Instant.class));
+        verify(refreshTokenRepository).revokeAllInFamily(eq(family), any(Instant.class));
     }
 
     @Test
@@ -194,13 +194,14 @@ class RefreshTokenServiceTest {
     @Test
     void revokeByRefresh_existingToken_revokesFamily() {
         when(timeTokenUtils.hash("raw")).thenReturn("hash");
-        RefreshToken token = RefreshToken.builder().family(RefreshTokenFamily.builder().id(5L).build()).build();
+        RefreshTokenFamily family = RefreshTokenFamily.builder().id(5L).build();
+        RefreshToken token = RefreshToken.builder().family(family).build();
         when(refreshTokenRepository.findByTokenHash("hash")).thenReturn(Optional.of(token));
 
         refreshTokenService.revokeByRefresh("raw");
 
         verify(familyRepository).revokeFamily(eq(5L), any(Instant.class));
-        verify(refreshTokenRepository).revokeAllInFamily(eq(5L), any(Instant.class));
+        verify(refreshTokenRepository).revokeAllInFamily(eq(family), any(Instant.class));
     }
 
     @Test


### PR DESCRIPTION
Fixed the refresh-token family foreign key and aligned the RefreshToken model, repository, and service.

## Development links
Closes #71
Closes #123
Closes #147
Closes #148
Closes #393
Closes #394