### PR TITLE
chore: run reconstructed backlog closer

### DIFF
--- a/.github/backlog-closer-trigger.txt
+++ b/.github/backlog-closer-trigger.txt
@@ -1,0 +1,1 @@
+One-time trigger for reconstructed backlog completion.


### PR DESCRIPTION
Temporary internal pull request used to attempt a one-time backlog status migration. The workflow was not started by GitHub, so this PR was closed without merge.